### PR TITLE
bot: Update taskcluster service check

### DIFF
--- a/bot/code_review_bot/tools/taskcluster.py
+++ b/bot/code_review_bot/tools/taskcluster.py
@@ -18,13 +18,6 @@ logger = structlog.get_logger(__name__)
 
 TASKCLUSTER_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
-with open(taskcluster._client_importer.__file__) as f:
-    TASKCLUSTER_SERVICES = [
-        line.split(' ')[1][1:]
-        for line in f.read().split('\n')
-        if line
-    ]
-
 
 def read_hosts():
     '''
@@ -114,10 +107,9 @@ class TaskclusterConfig(object):
         Build a Taskcluster service instance using current authentication
         '''
         assert self.options is not None, 'Not authenticated'
-        assert service_name in TASKCLUSTER_SERVICES, \
-            f'Service `{service_name}` does not exists.'
-
-        return getattr(taskcluster, service_name.capitalize())(self.options)
+        service = getattr(taskcluster, service_name.capitalize(), None)
+        assert service is not None, 'Invalid Taskcluster service {}'.format(service_name)
+        return service(self.options)
 
     def load_secrets(self, name, project_name, required=[], existing=dict()):
         '''

--- a/bot/tests/test_tools.py
+++ b/bot/tests/test_tools.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from code_review_bot.tools.taskcluster import TaskclusterConfig
+
+
+def test_taskcluster_service():
+    '''
+    Test taskcluster service loader
+    '''
+    taskcluster = TaskclusterConfig()
+    taskcluster.options = {
+        'rootUrl': 'http://tc.test',
+    }
+
+    assert taskcluster.get_service('secrets') is not None
+    assert taskcluster.get_service('hooks') is not None
+    assert taskcluster.get_service('index') is not None
+    with pytest.raises(AssertionError) as e:
+        taskcluster.get_service('nope')
+    assert str(e.value) == 'Invalid Taskcluster service nope'


### PR DESCRIPTION
Needed on the latest version of TC client as `taskcluster._client_importer` is not available anymore.