### PR TITLE
bot: Add new Taskcluster routes

### DIFF
--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -25,7 +25,8 @@ from code_review_bot.tools.taskcluster import TASKCLUSTER_DATE_FORMAT
 
 logger = structlog.get_logger(__name__)
 
-TASKCLUSTER_NAMESPACE = 'project.releng.services.project.{channel}.static_analysis_bot.{name}'
+TASKCLUSTER_OLD_NAMESPACE = 'project.releng.services.project.{channel}.static_analysis_bot.{name}'
+TASKCLUSTER_NAMESPACE = 'project.relman.{channel}.code-review.{name}'
 TASKCLUSTER_INDEX_TTL = 7  # in days
 
 
@@ -152,10 +153,12 @@ class Workflow(object):
 
         # Build complete namespaces list, with monitoring update
         full_namespaces = [
-            TASKCLUSTER_NAMESPACE.format(channel=settings.app_channel, name=name)
+            ns.format(channel=settings.app_channel, name=name)
             for name in namespaces
+            for ns in (TASKCLUSTER_OLD_NAMESPACE, TASKCLUSTER_NAMESPACE)
         ]
         full_namespaces.append('project.releng.services.tasks.{}'.format(settings.taskcluster.task_id))
+        full_namespaces.append('project.relman.tasks.{}'.format(settings.taskcluster.task_id))
 
         # Index for all required namespaces
         for namespace in full_namespaces:

--- a/bot/taskcluster-hook.json
+++ b/bot/taskcluster-hook.json
@@ -79,13 +79,16 @@
         "provisionerId": "aws-provisioner-v1",
         "retries": 3,
         "routes": [
-            "index.project.releng.services.project.CHANNEL.static_analysis_bot.latest"
+            "index.project.releng.services.project.CHANNEL.static_analysis_bot.latest",
+            "index.project.relman.CHANNEL.code-review.latest"
         ],
         "schedulerId": "-",
         "scopes": [
             "secrets:get:project/relman/code-review/runtime-CHANNEL",
             "index:insert-task:project.releng.services.project.CHANNEL.static_analysis_bot.*",
             "index:insert-task:project.releng.services.tasks.*",
+            "index:insert-task:project.relman.CHANNEL.code-review.*",
+            "index:insert-task:project.relman.tasks.*",
             "notify:email:*"
         ],
         "tags": {},


### PR DESCRIPTION
Refs #34 

I simply add the new `project.relman` routes in paralllel of the existing ones.
We'll run this for at least a week in production, in order to have both indexations at the same time.
The frontend will then be switched to the new route, and the old route will be removed from the bot.