### PR TITLE
Add .vscode/ exclusion to .gitignore for vscode developers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.vscode/
 *.pyc
 *.egg-info


### PR DESCRIPTION
For the developers that use `vscode` it would be nice to have the auto-generated workspace configuration excluded from `git`.