### PR TITLE
Remove old releng routes

### DIFF
--- a/bot/code_review_bot/retrigger.py
+++ b/bot/code_review_bot/retrigger.py
@@ -7,7 +7,9 @@ import requests
 
 from code_review_bot import taskcluster
 
-TC_INDEX_URL = "https://index.taskcluster.net/v1/tasks/project.releng.services.project.{}.static_analysis_bot.phabricator"
+TC_INDEX_URL = (
+    "https://index.taskcluster.net/v1/tasks/project.relman.{}.code-review.phabricator"
+)
 
 
 def list_tasks(env):
@@ -50,7 +52,7 @@ def main(env):
 
         extra_env = {"ANALYSIS_SOURCE": "phabricator", "ANALYSIS_ID": phid}
         task = hooks.triggerHook(
-            "project-releng", "services-{}-staticanalysis/bot".format(env), extra_env
+            "project-relman", "code-review-{}".format(env), extra_env
         )
         print(">> New task {}".format(task["status"]["taskId"]))
         total += 1

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -25,9 +25,6 @@ from code_review_bot.tools.taskcluster import TASKCLUSTER_DATE_FORMAT
 
 logger = structlog.get_logger(__name__)
 
-TASKCLUSTER_OLD_NAMESPACE = (
-    "project.releng.services.project.{channel}.static_analysis_bot.{name}"
-)
 TASKCLUSTER_NAMESPACE = "project.relman.{channel}.code-review.{name}"
 TASKCLUSTER_INDEX_TTL = 7  # in days
 
@@ -173,13 +170,9 @@ class Workflow(object):
 
         # Build complete namespaces list, with monitoring update
         full_namespaces = [
-            ns.format(channel=settings.app_channel, name=name)
+            TASKCLUSTER_NAMESPACE.format(channel=settings.app_channel, name=name)
             for name in namespaces
-            for ns in (TASKCLUSTER_OLD_NAMESPACE, TASKCLUSTER_NAMESPACE)
         ]
-        full_namespaces.append(
-            "project.releng.services.tasks.{}".format(settings.taskcluster.task_id)
-        )
         full_namespaces.append(
             "project.relman.tasks.{}".format(settings.taskcluster.task_id)
         )

--- a/bot/taskcluster-hook.json
+++ b/bot/taskcluster-hook.json
@@ -79,14 +79,11 @@
         "provisionerId": "aws-provisioner-v1",
         "retries": 3,
         "routes": [
-            "index.project.releng.services.project.CHANNEL.static_analysis_bot.latest",
             "index.project.relman.CHANNEL.code-review.latest"
         ],
         "schedulerId": "-",
         "scopes": [
             "secrets:get:project/relman/code-review/runtime-CHANNEL",
-            "index:insert-task:project.releng.services.project.CHANNEL.static_analysis_bot.*",
-            "index:insert-task:project.releng.services.tasks.*",
             "index:insert-task:project.relman.CHANNEL.code-review.*",
             "index:insert-task:project.relman.tasks.*",
             "notify:email:*"

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -49,25 +49,11 @@ def test_taskcluster_index(mock_config, mock_workflow, mock_try_task):
     )
     mock_workflow.index(rev, test="dummy")
 
-    assert mock_workflow.index_service.insertTask.call_count == 6
+    assert mock_workflow.index_service.insertTask.call_count == 3
     calls = mock_workflow.index_service.insertTask.call_args_list
 
     # First call with namespace
     namespace, args = calls[0][0]
-    assert (
-        namespace
-        == "project.releng.services.project.test.static_analysis_bot.mock.1234"
-    )
-    assert args["taskId"] == "12345deadbeef"
-    assert args["data"]["test"] == "dummy"
-    assert args["data"]["id"] == "1234"
-    assert args["data"]["source"] == "try"
-    assert args["data"]["try_task_id"] == "remoteTryTask"
-    assert args["data"]["try_group_id"] == "remoteTryGroup"
-    assert args["data"]["repository"] == "test-repo"
-    assert args["data"]["someData"] == "mock"
-    assert "indexed" in args["data"]
-    namespace, args = calls[1][0]
     assert namespace == "project.relman.test.code-review.mock.1234"
     assert args["taskId"] == "12345deadbeef"
     assert args["data"]["test"] == "dummy"
@@ -80,21 +66,7 @@ def test_taskcluster_index(mock_config, mock_workflow, mock_try_task):
     assert "indexed" in args["data"]
 
     # Second call with sub namespace
-    namespace, args = calls[2][0]
-    assert (
-        namespace
-        == "project.releng.services.project.test.static_analysis_bot.mock.1234.12345deadbeef"
-    )
-    assert args["taskId"] == "12345deadbeef"
-    assert args["data"]["test"] == "dummy"
-    assert args["data"]["id"] == "1234"
-    assert args["data"]["source"] == "try"
-    assert args["data"]["try_task_id"] == "remoteTryTask"
-    assert args["data"]["try_group_id"] == "remoteTryGroup"
-    assert args["data"]["repository"] == "test-repo"
-    assert args["data"]["someData"] == "mock"
-    assert "indexed" in args["data"]
-    namespace, args = calls[3][0]
+    namespace, args = calls[1][0]
     assert namespace == "project.relman.test.code-review.mock.1234.12345deadbeef"
     assert args["taskId"] == "12345deadbeef"
     assert args["data"]["test"] == "dummy"
@@ -107,17 +79,7 @@ def test_taskcluster_index(mock_config, mock_workflow, mock_try_task):
     assert "indexed" in args["data"]
 
     # Third call for monitoring
-    namespace, args = calls[4][0]
-    assert namespace == "project.releng.services.tasks.12345deadbeef"
-    assert args["taskId"] == "12345deadbeef"
-    assert args["data"]["test"] == "dummy"
-    assert args["data"]["id"] == "1234"
-    assert args["data"]["source"] == "try"
-    assert args["data"]["try_task_id"] == "remoteTryTask"
-    assert args["data"]["try_group_id"] == "remoteTryGroup"
-    assert args["data"]["repository"] == "test-repo"
-    assert args["data"]["monitoring_restart"] is False
-    namespace, args = calls[5][0]
+    namespace, args = calls[2][0]
     assert namespace == "project.relman.tasks.12345deadbeef"
     assert args["taskId"] == "12345deadbeef"
     assert args["data"]["test"] == "dummy"
@@ -141,39 +103,27 @@ def test_monitoring_restart(mock_config, mock_workflow):
 
     # Unsupported error code
     mock_workflow.index(rev, test="dummy", error_code="nope", state="error")
-    assert mock_workflow.index_service.insertTask.call_count == 2
+    assert mock_workflow.index_service.insertTask.call_count == 1
     calls = mock_workflow.index_service.insertTask.call_args_list
     namespace, args = calls[0][0]
-    assert namespace == "project.releng.services.tasks.someTaskId"
-    assert args["taskId"] == "someTaskId"
-    assert args["data"]["monitoring_restart"] is False
-    namespace, args = calls[1][0]
     assert namespace == "project.relman.tasks.someTaskId"
     assert args["taskId"] == "someTaskId"
     assert args["data"]["monitoring_restart"] is False
 
     # watchdog should be restated
     mock_workflow.index(rev, test="dummy", error_code="watchdog", state="error")
-    assert mock_workflow.index_service.insertTask.call_count == 4
+    assert mock_workflow.index_service.insertTask.call_count == 2
     calls = mock_workflow.index_service.insertTask.call_args_list
-    namespace, args = calls[2][0]
-    assert namespace == "project.releng.services.tasks.someTaskId"
-    assert args["taskId"] == "someTaskId"
-    assert args["data"]["monitoring_restart"] is True
-    namespace, args = calls[3][0]
+    namespace, args = calls[1][0]
     assert namespace == "project.relman.tasks.someTaskId"
     assert args["taskId"] == "someTaskId"
     assert args["data"]["monitoring_restart"] is True
 
     # Invalid state
     mock_workflow.index(rev, test="dummy", state="running")
-    assert mock_workflow.index_service.insertTask.call_count == 6
+    assert mock_workflow.index_service.insertTask.call_count == 3
     calls = mock_workflow.index_service.insertTask.call_args_list
-    namespace, args = calls[4][0]
-    assert namespace == "project.releng.services.tasks.someTaskId"
-    assert args["taskId"] == "someTaskId"
-    assert args["data"]["monitoring_restart"] is False
-    namespace, args = calls[5][0]
+    namespace, args = calls[2][0]
     assert namespace == "project.relman.tasks.someTaskId"
     assert args["taskId"] == "someTaskId"
     assert args["data"]["monitoring_restart"] is False


### PR DESCRIPTION
Fixes #34

This is now possible as the production has run for 18 days with both namespaces : https://tools.taskcluster.net/index/project.relman.production.code-review.phabricator

