### PR TITLE
bot: Specify default path to third party

### DIFF
--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -62,6 +62,7 @@ class Settings(object):
                 "java_extensions": frozenset([".java"]),
                 "idl_extenssions": frozenset([".idl"]),
                 "js_extensions": frozenset([".js", ".jsm"]),
+                "third_party": "tools/rewriting/ThirdPartyPaths.txt",
             }
         )
         assert "clang_checkers" in self.config


### PR DESCRIPTION
As the  `third_party` declaration has been removed from https://hg.mozilla.org/mozilla-central/file/tip/tools/clang-tidy/config.yaml by @sylvestre & @abpostelnicu in https://phabricator.services.mozilla.com/D44163

This break the bot :sob: 

