### PR TITLE
bot: Remove 3rd party detection

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -123,12 +123,6 @@ class Issue(abc.ABC):
         """
         return False
 
-    def is_third_party(self):
-        """
-        Is this issue in a third party path ?
-        """
-        return settings.is_third_party(self.path)
-
 
 class Reliability(enum.Enum):
     Unknown = "unknown"

--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -62,7 +62,6 @@ class Settings(object):
                 "java_extensions": frozenset([".java"]),
                 "idl_extenssions": frozenset([".idl"]),
                 "js_extensions": frozenset([".js", ".jsm"]),
-                "third_party": "tools/rewriting/ThirdPartyPaths.txt",
             }
         )
         assert "clang_checkers" in self.config
@@ -123,19 +122,6 @@ class Settings(object):
         self.config = defaults
         self.config.update(yaml.safe_load(_fetch("tools/clang-tidy/config.yaml")))
         logger.info("Loaded configuration from mozilla-central")
-
-        # Also downloads the 3rd party file
-        self.third_party_paths = _fetch(self.third_party).decode("utf-8").splitlines()
-        logger.info("Loaded {} third party paths".format(len(self.third_party_paths)))
-
-    def is_third_party(self, path):
-        """
-        Check if a file is a 3rd party
-        """
-        for third_party_path in self.third_party_paths:
-            if path.startswith(third_party_path):
-                return True
-        return False
 
     def is_publishable_check(self, check):
         """

--- a/bot/code_review_bot/tasks/clang_format.py
+++ b/bot/code_review_bot/tasks/clang_format.py
@@ -49,7 +49,7 @@ class ClangFormatIssue(Issue):
         """
         Should match one of the allowed paths rules
         """
-        return settings.is_allowed_path(self.path) and not self.is_third_party()
+        return settings.is_allowed_path(self.path)
 
     def as_text(self):
         """

--- a/bot/code_review_bot/tasks/clang_tidy.py
+++ b/bot/code_review_bot/tasks/clang_tidy.py
@@ -26,7 +26,6 @@ ISSUE_MARKDOWN = """
 - **In patch**: {in_patch}
 - **Clang check**: {check}
 - **Publishable check**: {publishable_check}
-- **Third Party**: {third_party}
 - **Expanded Macro**: {expanded_macro}
 - **Publishable **: {publishable}
 - **Is new**: {is_new}
@@ -104,15 +103,10 @@ class ClangTidyIssue(Issue):
     def validates(self):
         """
         Publish clang-tidy issues when:
-        * not a third party code
         * check is marked as publishable
         * is not from an expanded macro
         """
-        return (
-            self.has_publishable_check()
-            and not self.is_third_party()
-            and not self.is_expanded_macro()
-        )
+        return self.has_publishable_check() and not self.is_expanded_macro()
 
     def is_expanded_macro(self):
         """
@@ -167,7 +161,6 @@ class ClangTidyIssue(Issue):
             reason=self.reason,
             check=self.check,
             in_patch="yes" if self.revision.contains(self) else "no",
-            third_party="yes" if self.is_third_party() else "no",
             publishable_check="yes" if self.has_publishable_check() else "no",
             publishable="yes" if self.is_publishable() else "no",
             expanded_macro="yes" if self.is_expanded_macro() else "no",
@@ -203,7 +196,6 @@ class ClangTidyIssue(Issue):
             "notes": [note.as_dict() for note in self.notes],
             "validation": {
                 "publishable_check": self.has_publishable_check(),
-                "third_party": self.is_third_party(),
                 "is_expanded_macro": self.is_expanded_macro(),
             },
             "in_patch": self.revision.contains(self),

--- a/bot/code_review_bot/tasks/coverage.py
+++ b/bot/code_review_bot/tasks/coverage.py
@@ -14,7 +14,6 @@ ISSUE_MARKDOWN = """
 ## coverage problem
 
 - **Path**: {path}
-- **Third Party**: {third_party}
 - **Publishable**: {publishable}
 
 ```
@@ -62,7 +61,6 @@ class CoverageIssue(Issue):
         return ISSUE_MARKDOWN.format(
             path=self.path,
             message=self.message,
-            third_party=self.is_third_party() and "yes" or "no",
             publishable=self.is_publishable() and "yes" or "no",
             is_new=self.is_new and "yes" or "no",
         )
@@ -76,7 +74,6 @@ class CoverageIssue(Issue):
             "path": self.path,
             "line": self.line,
             "message": self.message,
-            "is_third_party": self.is_third_party(),
             "in_patch": self.revision.contains(self),
             "is_new": self.is_new,
             "validates": self.validates(),

--- a/bot/code_review_bot/tasks/lint.py
+++ b/bot/code_review_bot/tasks/lint.py
@@ -14,7 +14,6 @@ ISSUE_MARKDOWN = """
 - **Path**: {path}
 - **Level**: {level}
 - **Line**: {line}
-- **Third Party**: {third_party}
 - **Disabled rule**: {disabled_rule}
 - **Publishable**: {publishable}
 - **Is new**: {is_new}
@@ -74,10 +73,9 @@ class MozLintIssue(Issue):
     def validates(self):
         """
         A mozlint issues is publishable when:
-        * file is not 3rd party
         * rule is not disabled
         """
-        return not self.is_third_party() and not self.is_disabled_rule()
+        return not self.is_disabled_rule()
 
     def as_text(self):
         """
@@ -99,7 +97,6 @@ class MozLintIssue(Issue):
             level=self.level,
             line=self.line,
             message=self.message,
-            third_party=self.is_third_party() and "yes" or "no",
             publishable=self.is_publishable() and "yes" or "no",
             disabled_rule=self.is_disabled_rule() and "yes" or "no",
             is_new=self.is_new and "yes" or "no",

--- a/bot/tests/test_clang.py
+++ b/bot/tests/test_clang.py
@@ -103,11 +103,7 @@ def test_as_dict(mock_revision):
         "body": "Dummy body withUppercaseChars",
         "reason": None,
         "notes": [],
-        "validation": {
-            "publishable_check": False,
-            "third_party": False,
-            "is_expanded_macro": False,
-        },
+        "validation": {"publishable_check": False, "is_expanded_macro": False},
         "in_patch": False,
         "is_new": False,
         "validates": False,
@@ -145,7 +141,6 @@ def test_as_markdown(mock_revision):
 - **In patch**: no
 - **Clang check**: dummy-check
 - **Publishable check**: no
-- **Third Party**: no
 - **Expanded Macro**: no
 - **Publishable **: no
 - **Is new**: no
@@ -167,25 +162,3 @@ Dummy body
         "path": "test.cpp",
         "severity": "warning",
     }
-
-
-def test_clang_format_3rd_party(mock_config, mock_revision):
-    """
-    Test a clang format issue in 3rd party is not publishable
-    """
-    from code_review_bot.tasks.clang_format import ClangFormatIssue
-
-    mock_revision.lines = {"test/not_3rd.c": [10], "test/dummy/third_party.c": [10]}
-    issue = ClangFormatIssue("test/not_3rd.c", 10, 1, mock_revision)
-    assert issue.is_publishable()
-    assert issue.as_phabricator_lint() == {
-        "code": "clang-format",
-        "line": 10,
-        "name": "C/C++ style issue",
-        "path": "test/not_3rd.c",
-        "severity": "warning",
-    }
-
-    # test/dummy is a third party directory
-    issue = ClangFormatIssue("test/dummy/third_party.c", 10, 1, mock_revision)
-    assert not issue.is_publishable()

--- a/bot/tests/test_coverage.py
+++ b/bot/tests/test_coverage.py
@@ -42,7 +42,6 @@ def test_coverage(mock_config, mock_revision, mock_coverage_artifact):
         "message": "This file is uncovered",
         "in_patch": True,
         "is_new": False,
-        "is_third_party": False,
         "validates": True,
         "publishable": True,
     }
@@ -60,7 +59,6 @@ def test_coverage(mock_config, mock_revision, mock_coverage_artifact):
 ## coverage problem
 
 - **Path**: my/path/file1.cpp
-- **Third Party**: no
 - **Publishable**: yes
 
 ```
@@ -84,7 +82,6 @@ This file is uncovered
         "message": "This file is uncovered",
         "in_patch": True,
         "is_new": False,
-        "is_third_party": True,
         "validates": True,
         "publishable": True,
     }
@@ -102,7 +99,6 @@ This file is uncovered
 ## coverage problem
 
 - **Path**: test/dummy/thirdparty.c
-- **Third Party**: yes
 - **Publishable**: yes
 
 ```
@@ -126,7 +122,6 @@ This file is uncovered
         "message": "This file is uncovered",
         "in_patch": True,
         "is_new": False,
-        "is_third_party": False,
         "validates": False,
         "publishable": False,
     }
@@ -144,7 +139,6 @@ This file is uncovered
 ## coverage problem
 
 - **Path**: my/path/header.h
-- **Third Party**: no
 - **Publishable**: no
 
 ```

--- a/bot/tests/test_lint.py
+++ b/bot/tests/test_lint.py
@@ -17,21 +17,6 @@ def test_flake8_rules(mock_config, mock_revision):
     assert not issue.is_disabled_rule()
     assert issue.validates()
 
-    # 3rd party
-    issue = MozLintIssue(
-        "test/dummy/XXX.py",
-        1,
-        "error",
-        1,
-        "flake8",
-        "Dummy test",
-        "dummy rule",
-        mock_revision,
-    )
-    assert not issue.is_disabled_rule()
-    assert issue.is_third_party()
-    assert not issue.validates()
-
     # Flake8 bad quotes
     issue = MozLintIssue(
         "test.py",


### PR DESCRIPTION
Refs #28 

This PR removes Third party detection from the bot, as it was only for mozilla-central, and makes the bot dependant on external files.

Affected analyzers are:
* **mozlint**, but it's OK as it's already supported [in-tree for a while](https://searchfox.org/mozilla-central/source/tools/lint/mach_commands.py#40)
* **clang-format**, but it's OK as it's already supported [in-tree for a while](https://searchfox.org/mozilla-central/source/python/mozbuild/mozbuild/code-analysis/mach_commands.py#1892)
* **clang-tidy**, this is dependant on my own work in [Bug 1550517](https://bugzilla.mozilla.org/show_bug.cgi?id=1550517), and uses the same function as clang-format.