### PR TITLE
tools: Use our naming scheme for Sentry.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 known_first_party = code_review_bot,code_review_tools,code_review_events,conftest
-known_third_party = influxdb,libmozdata,libmozevent,logbook,parsepatch,pytest,requests,responses,setuptools,structlog,taskcluster,toml
+known_third_party = influxdb,libmozdata,libmozevent,logbook,parsepatch,pytest,raven,requests,responses,setuptools,structlog,taskcluster,toml
 force_single_line = True
 default_section=FIRSTPARTY
 line_length=159


### PR DESCRIPTION
To be more consistent with code-coverage, and use our own naming scheme instead of release-services.