### PR TITLE
bot: Send email to differential owner when build failures are encountered, fixes #99

### DIFF
--- a/bot/code_review_bot/report/__init__.py
+++ b/bot/code_review_bot/report/__init__.py
@@ -6,6 +6,7 @@
 import structlog
 
 from code_review_bot.report.mail import MailReporter
+from code_review_bot.report.mail_builderrors import BuildErrorsReporter
 from code_review_bot.report.phabricator import PhabricatorReporter
 
 logger = structlog.get_logger(__name__)
@@ -16,7 +17,12 @@ def get_reporters(configuration):
     Load reporters using Taskcluster configuration
     """
     assert isinstance(configuration, list)
-    reporters = {"mail": MailReporter, "phabricator": PhabricatorReporter}
+    reporters = {
+        "mail": MailReporter,
+        "build_error": BuildErrorsReporter,
+        "phabricator": PhabricatorReporter,
+    }
+
     out = {}
     for conf in configuration:
         try:

--- a/bot/code_review_bot/report/mail_builderrors.py
+++ b/bot/code_review_bot/report/mail_builderrors.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import structlog
+
+from code_review_bot import taskcluster
+from code_review_bot.report.base import Reporter
+
+logger = structlog.get_logger(__name__)
+
+EMAIL_HEADER = """
+# Found {build_errors} build errors.
+
+Review Url: {review_url}
+
+"""
+
+
+class BuildErrorsReporter(Reporter):
+    """
+    Send an email to the author of the revision in case there are build errors
+    """
+
+    def __init__(self, configuration):
+        # Load TC services
+        self.notify = taskcluster.get_service("notify")
+
+        logger.info("BuildErrorsReporter report enabled.")
+
+    def publish(self, issues, revision):
+        """
+        Send an email to the author of the revision
+        """
+
+        assert (
+            "attachments" in revision.diff
+        ), "Unable to find the commits for revision {}.".format(revision.phid)
+
+        attachments = revision.diff["attachments"]
+
+        if "commits" not in attachments and "commits" not in attachments["commits"]:
+            logger.info(
+                "Unable to find the commits for revision {}.".format(revision.phid)
+            )
+            return
+
+        build_errors = [issue for issue in issues if issue.is_build_error()]
+
+        if not build_errors:
+            logger.info("No build errors encountered.")
+            return
+
+        content = EMAIL_HEADER.format(
+            build_errors=len(build_errors), review_url=revision.url
+        )
+
+        content += "\n\n".join([i.as_markdown() for i in build_errors])
+
+        if len(content) > 102400:
+            # Content is 102400 chars max
+            content = content[:102000] + "\n\n... Content max limit reached!"
+
+        subject = "Build errors encountered for {}".format(revision)
+
+        # Get the last commit
+        commit = attachments["commits"]["commits"][-1]
+
+        if "author" not in commit:
+            logger.info("Unable to find the author for commit.")
+            return
+
+        # Since we nw know that there is an "author" field we assume that we have "email"
+        self.notify.email(
+            {
+                "address": commit["author"]["email"],
+                "subject": subject,
+                "content": content,
+            }
+        )

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -125,7 +125,11 @@ class Revision(object):
         assert self.diff_phid.startswith("PHID-DIFF-")
 
         # Load diff details to get the diff revision
-        diffs = self.api.search_diffs(diff_phid=self.diff_phid)
+        # We also load the commits list in order to get the email of the author of the
+        # patch for sending email if builds are failing.
+        diffs = self.api.search_diffs(
+            diff_phid=self.diff_phid, attachments={"commits": True}
+        )
         assert len(diffs) == 1, "No diff available for {}".format(self.diff_phid)
         self.diff = diffs[0]
         self.diff_id = self.diff["id"]

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -59,6 +59,9 @@ def mock_issues():
         def is_publishable(self):
             return self.nb % 2 == 0
 
+        def is_build_error(self):
+            return self.nb % 4 == 0
+
     return [MockIssue(i) for i in range(5)]
 
 

--- a/bot/tests/mocks/phabricator_diff_search.json
+++ b/bot/tests/mocks/phabricator_diff_search.json
@@ -25,7 +25,26 @@
                         "view": "public"
                     }
                 },
-                "attachments": {}
+                "attachments": {
+                    "commits": {
+                        "commits": [
+                            {
+                                "identifier": "dcfebedebe9f18bce45f9bfc0339fe8255e5468b",
+                                "tree": null,
+                                "parents": [
+                                    "083ea767da9b11d52d71c227415d2a1b4fab6173"
+                                ],
+                                "author": {
+                                    "name": "test",
+                                    "email": "test@mozilla.com",
+                                    "raw": "\"test\" <test>",
+                                    "epoch": 0
+                                },
+                                "message": "create update for phabsend test\n\nDifferential Revision: https://phabricator-dev.allizom.org/D1354"
+                            }
+                        ]
+                    }
+                }
             }
         ],
         "maps": {},


### PR DESCRIPTION
Since `Phabricator` doesn't offer support for sending email when UnitTest failures happen we need to have this specific implementation in order to inform patch owners when build failure happen.