### PR TITLE
bot: Add a warning when an absolute path is cleaned

### DIFF
--- a/bot/code_review_bot/tasks/base.py
+++ b/bot/code_review_bot/tasks/base.py
@@ -121,6 +121,7 @@ class AnalysisTask(object):
         for checkout in WORKER_CHECKOUTS:
             if path.startswith(checkout):
                 self.cleaned_paths.add(path)
+                logger.warning("Cleaned issue absolute path", path=path, name=self.name)
                 return os.path.relpath(path, checkout)
 
         return path

--- a/bot/requirements-dev.txt
+++ b/bot/requirements-dev.txt
@@ -1,4 +1,5 @@
 pre-commit==1.18.3
 pytest==5.1.3
 pytest-responses==0.4.0
+pytest-structlog==0.1
 responses==0.10.6

--- a/bot/tests/test_coverity.py
+++ b/bot/tests/test_coverity.py
@@ -14,6 +14,7 @@ class MockCoverityTask(CoverityTask):
         Simply skip task loading
         """
         self.cleaned_paths = set()
+        self.task = {"metadata": {"name": "mock-coverity"}}
 
 
 def mock_coverity(name):
@@ -26,7 +27,7 @@ def mock_coverity(name):
         return {"public/code-review/coverity.json": json.load(f)}
 
 
-def test_simple(mock_revision, mock_config):
+def test_simple(mock_revision, mock_config, log):
     """
     Test parsing a simple Coverity artifact
     """
@@ -81,6 +82,14 @@ The path that leads to this defect is:
     }
     assert issue.body is None
     assert issue.nb_lines == 1
+
+    # Check the issue's absolute path has been cleaned
+    assert log.has(
+        "Cleaned issue absolute path",
+        path="/builds/worker/checkouts/gecko/js/src/jit/BaselineCompiler.cpp",
+        name="mock-coverity",
+        level="warning",
+    )
 
     assert issue.validates()
     assert not issue.is_publishable()

--- a/bot/tests/test_issues.py
+++ b/bot/tests/test_issues.py
@@ -3,13 +3,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import pytest
+
+from code_review_bot.tasks.base import AnalysisTask
+from code_review_bot.tasks.clang_format import ClangFormatIssue
+
 
 def test_allowed_paths(mock_config):
     """
     Test allowed paths for ClangFormatIssue
     The test config has these 2 rules: dom/* and tests/*.py
     """
-    from code_review_bot.tasks.clang_format import ClangFormatIssue
 
     def _allowed(path):
         # Build an issue and check its validation
@@ -28,3 +32,36 @@ def test_allowed_paths(mock_config):
     }
     for path, result in checks.items():
         assert _allowed(path) is result
+
+
+@pytest.mark.parametrize(
+    "path, cleaned_path",
+    [
+        ("myfile.cpp", "myfile.cpp"),
+        # Unknown full path
+        ("/absolute/path/file.rs", "/absolute/path/file.rs"),
+        # Known full paths
+        ("/builds/worker/checkouts/gecko/js/xx.h", "js/xx.h"),
+        ("/home/worker/nss/something.py", "something.py"),
+        ("/home/worker/nspr/Test.c", "Test.c"),
+    ],
+)
+def test_cleaned_paths(log, path, cleaned_path):
+    """
+    Test cleaning a path using a known worker's checkout
+    """
+    assert len(log.events) == 0
+
+    task = AnalysisTask(
+        "testTask", {"task": {"metadata": {"name": "test-task"}}, "status": None}
+    )
+    assert task.clean_path(path) == cleaned_path
+
+    # Check a warning is sent when path is cleaned
+    if path == cleaned_path:
+        assert len(log.events) == 0
+    else:
+        assert len(log.events) == 1
+        assert log.has(
+            "Cleaned issue absolute path", path=path, name="test-task", level="warning"
+        )


### PR DESCRIPTION
Refs #45.

Sending a warning when an absolute path is cleaned will allow us to track the usage function through Sentry.
As all analyzers on MC & NSS now output relative paths, we should be able to remove this cleanup if we see 0 warnings in the next few weeks.