### PR TITLE
bot: Log email address that is used when reporting build errors.

### DIFF
--- a/bot/code_review_bot/report/mail_builderrors.py
+++ b/bot/code_review_bot/report/mail_builderrors.py
@@ -71,6 +71,8 @@ class BuildErrorsReporter(Reporter):
             logger.info("Unable to find the author for commit.")
             return
 
+        logger.info("Send build error email", to=commit["author"]["email"])
+
         # Since we nw know that there is an "author" field we assume that we have "email"
         self.notify.email(
             {


### PR DESCRIPTION
As @La0 suggested we should add a log with the email that is used when sending a notification email when a build error occurs. 