### PR TITLE
bot: add dedicated markdown for issues that are build errors.

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -94,6 +94,12 @@ class Issue(abc.ABC):
         """
         raise NotImplementedError
 
+    def as_error(self):
+        """
+        Build the Markdown content for for build error issues
+        """
+        raise NotImplementedError
+
     @abc.abstractmethod
     def as_dict(self):
         """

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -14,6 +14,7 @@ from libmozdata.phabricator import PhabricatorAPI
 
 from code_review_bot import stats
 from code_review_bot.config import settings
+from code_review_bot.tasks.coverity import CoverityIssue
 
 MOCK_DIR = os.path.join(os.path.dirname(__file__), "mocks")
 FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
@@ -63,6 +64,29 @@ def mock_issues():
             return self.nb % 4 == 0
 
     return [MockIssue(i) for i in range(5)]
+
+
+@pytest.fixture
+def mock_coverity_issues():
+    """
+    Build a list of Coverity issues
+    """
+
+    return [
+        CoverityIssue(
+            0,
+            {
+                "reliability": "high",
+                "line": i,
+                "build_error": True,
+                "message": "Unidentified symbol",
+                "extra": {"category": "bug", "stateOnServer": False},
+                "flag": "flag",
+            },
+            "some/file/path",
+        )
+        for i in range(2)
+    ]
 
 
 @pytest.fixture

--- a/bot/tests/test_reporter_mail.py
+++ b/bot/tests/test_reporter_mail.py
@@ -31,13 +31,16 @@ This is the mock issue n°3
 This is the mock issue n°4"""
 
 MAIL_CONTENT_BUILD_ERRORS = """
-# Found 2 build errors.
+# [Code Review bot](https://github.com/mozilla/code-review) found 2 build errors on [D51](https://phabricator.test/D51)
 
-Review Url: https://phabricator.test/D51
 
-This is the mock issue n°0
+**Message**: ```Unidentified symbol```
+**Location**: some/file/path:0
 
-This is the mock issue n°4"""
+
+**Message**: ```Unidentified symbol```
+**Location**: some/file/path:1
+"""
 
 
 def test_conf(mock_config, mock_taskcluster_config):
@@ -114,7 +117,7 @@ def test_mail(mock_config, mock_issues, mock_revision, mock_taskcluster_config):
 
 
 def test_mail_builderrors(
-    mock_config, mock_issues, mock_revision, mock_taskcluster_config
+    log, mock_config, mock_coverity_issues, mock_revision, mock_taskcluster_config
 ):
     """
     Test mail_builderrors sending through Taskcluster
@@ -124,9 +127,7 @@ def test_mail_builderrors(
     def _check_email(request):
         payload = json.loads(request.body)
 
-        assert payload["subject"] in (
-            "Build errors encountered for Phabricator #42 - PHID-DIFF-test",
-        )
+        assert payload["subject"] == "Code Review bot found 2 build errors on D51"
         assert payload["address"] == "test@mozilla.com"
         assert payload["content"] == MAIL_CONTENT_BUILD_ERRORS
 
@@ -143,4 +144,6 @@ def test_mail_builderrors(
     conf = {"emails": ["test@mozilla.com"]}
     r = BuildErrorsReporter(conf)
 
-    r.publish(mock_issues, mock_revision)
+    r.publish(mock_coverity_issues, mock_revision)
+
+    assert log.has("Send build error email", to="test@mozilla.com")


### PR DESCRIPTION
For build errors when we send targeted emails we must used separate markdowns.