### PR TITLE
Use python 3.7 as base image

### DIFF
--- a/events/docker/Dockerfile
+++ b/events/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.7-slim
 
 ADD tools /src/tools
 ADD events /src/events


### PR DESCRIPTION
It is required to install hiredis without needing to compile the binary part (python 3.8 needs gcc for now...)