### PR TITLE
bot: Do not crash when bugzilla id is missing

### DIFF
--- a/bot/code_review_bot/report/backend.py
+++ b/bot/code_review_bot/report/backend.py
@@ -38,7 +38,7 @@ class BackendReporter(Reporter):
             "id": revision.id,
             "phid": revision.phid,
             "title": revision.title,
-            "bugzilla_id": int(revision.bugzilla_id),
+            "bugzilla_id": revision.bugzilla_id,
             "repository": revision.target_repository,
         }
         backend_revision = self.create("/v1/revision/", data)
@@ -80,6 +80,8 @@ class BackendReporter(Reporter):
         response = requests.post(
             url_post, json=data, auth=(self.username, self.password)
         )
+        if not response.ok:
+            logger.warn("Backend rejected the payload: {}".format(response.content))
         response.raise_for_status()
         out = response.json()
         logger.info("Created item on backend", url=url_post, id=out["id"])

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -348,7 +348,11 @@ class Revision(object):
 
     @property
     def bugzilla_id(self):
-        return self.revision["fields"].get("bugzilla.bug-id")
+        try:
+            return int(self.revision["fields"].get("bugzilla.bug-id"))
+        except ValueError:
+            logger.info("No bugzilla id available for this revision")
+            return None
 
     @property
     def title(self):

--- a/bot/tests/test_reporter_debug.py
+++ b/bot/tests/test_reporter_debug.py
@@ -50,7 +50,7 @@ def test_publication(tmpdir, mock_issues, mock_revision):
         "id": 51,
         "diff_id": 42,
         "url": "https://phabricator.test/D51",
-        "bugzilla_id": "1234567",
+        "bugzilla_id": 1234567,
         "diff_phid": "PHID-DIFF-test",
         "phid": "PHID-DREV-zzzzz",
         "title": "Static Analysis tests",


### PR DESCRIPTION
A fix for [this bug](https://tools.taskcluster.net/groups/Q7RwlvU8S22bnspPyo_0Wg/tasks/Q7RwlvU8S22bnspPyo_0Wg/runs/0/logs/public%2Flogs%2Flive.log) happening when a Phabricator revision does not have the bugzilla id

I'll push it on production once landed