### PR TITLE
Diff management & detailed APIs

### DIFF
--- a/backend/code_review_backend/issues/tests/test_diff.py
+++ b/backend/code_review_backend/issues/tests/test_diff.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import hashlib
+
+from django.contrib.auth.models import User
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from code_review_backend.issues.models import Diff
+from code_review_backend.issues.models import Repository
+
+
+class DiffAPITestCase(APITestCase):
+    def setUp(self):
+        # Create a user
+        self.user = User.objects.create(username="crash_user")
+
+        # Create a repo
+        self.repo = Repository.objects.create(
+            id=1, phid="PHID-REPO-xxx", slug="myrepo", url="http://repo.test/myrepo"
+        )
+
+        # Create a stack with 2 revisions & 3 diffs
+        for i in range(2):
+            self.repo.revisions.create(
+                id=i + 1,
+                phid=f"PHID-DREV-{i+1}",
+                title=f"Revision {i+1}",
+                bugzilla_id=10000 + i,
+            )
+        for i in range(3):
+            Diff.objects.create(
+                id=i + 1,
+                phid=f"PHID-DIFF-{i+1}",
+                revision_id=(i % 2) + 1,
+                review_task_id=f"task-{i}",
+                mercurial_hash=hashlib.sha1(f"hg {i}".encode("utf-8")).hexdigest(),
+            )
+
+    def test_list_diffs(self):
+        """
+        Check we can list all diffs with their revision
+        """
+        response = self.client.get("/v1/diff/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertDictEqual(
+            response.json(),
+            {
+                "count": 3,
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "id": 1,
+                        "revision": {
+                            "id": 1,
+                            "repository": "myrepo",
+                            "phid": "PHID-DREV-1",
+                            "title": "Revision 1",
+                            "bugzilla_id": 10000,
+                            "diffs_url": "http://testserver/v1/revision/1/diffs/",
+                        },
+                        "phid": "PHID-DIFF-1",
+                        "review_task_id": "task-0",
+                        "mercurial_hash": "a2ac78b7d12d6e55b9b15c1c2048a16c58c6c803",
+                        "issues_url": "http://testserver/v1/diff/1/issues/",
+                        "nb_issues": 0,
+                    },
+                    {
+                        "id": 2,
+                        "revision": {
+                            "id": 2,
+                            "repository": "myrepo",
+                            "phid": "PHID-DREV-2",
+                            "title": "Revision 2",
+                            "bugzilla_id": 10001,
+                            "diffs_url": "http://testserver/v1/revision/2/diffs/",
+                        },
+                        "phid": "PHID-DIFF-2",
+                        "review_task_id": "task-1",
+                        "mercurial_hash": "32d2a594cfef74fcb524028d1521d0d4bd98bd35",
+                        "issues_url": "http://testserver/v1/diff/2/issues/",
+                        "nb_issues": 0,
+                    },
+                    {
+                        "id": 3,
+                        "revision": {
+                            "id": 1,
+                            "repository": "myrepo",
+                            "phid": "PHID-DREV-1",
+                            "title": "Revision 1",
+                            "bugzilla_id": 10000,
+                            "diffs_url": "http://testserver/v1/revision/1/diffs/",
+                        },
+                        "phid": "PHID-DIFF-3",
+                        "review_task_id": "task-2",
+                        "mercurial_hash": "30b501affc4d3b9c670fc297ab903b406afd5f04",
+                        "issues_url": "http://testserver/v1/diff/3/issues/",
+                        "nb_issues": 0,
+                    },
+                ],
+            },
+        )

--- a/bot/code_review_bot/report/backend.py
+++ b/bot/code_review_bot/report/backend.py
@@ -43,15 +43,14 @@ class BackendReporter(Reporter):
         }
         backend_revision = self.create("/v1/revision/", data)
 
-        # Create diff on backend
+        # Create diff attached to revision on backend
         data = {
             "id": revision.diff_id,
             "phid": revision.diff_phid,
-            "revision": backend_revision["id"],
             "review_task_id": settings.taskcluster.task_id,
             "mercurial_hash": revision.mercurial_revision,
         }
-        backend_diff = self.create("/v1/diff/", data)
+        backend_diff = self.create(backend_revision["diffs_url"], data)
 
         # Publish each issue on the backend
         for issue in issues:

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -463,8 +463,12 @@ def mock_backend():
         revision_id = payload["id"]
         if revision_id in revisions:
             return (400, {}, "")
+
+        # Add diffs_url to the output
+        payload["diffs_url"] = f"http://{host}/v1/revision/{revision_id}/diffs/"
+
         revisions[revision_id] = payload
-        return (201, {}, request.body)
+        return (201, {}, json.dumps(payload))
 
     def get_diff(request):
         """Get a diff when available in db"""
@@ -513,10 +517,14 @@ def mock_backend():
 
     # Diff
     responses.add_callback(
-        responses.GET, re.compile(rf"^http://{host}/v1/diff/(\d+)/$"), callback=get_diff
+        responses.GET,
+        re.compile(rf"^http://{host}/v1/revision/(\d+)/diffs/(\d+)/$"),
+        callback=get_diff,
     )
     responses.add_callback(
-        responses.POST, re.compile(f"^http://{host}/v1/diff/$"), callback=post_diff
+        responses.POST,
+        re.compile(rf"^http://{host}/v1/revision/(\d+)/diffs/$"),
+        callback=post_diff,
     )
 
     # Issues

--- a/bot/tests/test_reporter_backend.py
+++ b/bot/tests/test_reporter_backend.py
@@ -39,6 +39,7 @@ def test_publication(mock_coverity_issues, mock_revision, mock_backend, mock_hgm
         "phid": "PHID-DREV-zzzzz",
         "repository": "test",
         "title": "Static Analysis tests",
+        "diffs_url": "http://code-review-backend.test/v1/revision/51/diffs/",
     }
 
     # Check the diff in the backend
@@ -50,7 +51,6 @@ def test_publication(mock_coverity_issues, mock_revision, mock_backend, mock_hgm
         "mercurial_hash": "deadbeef1234",
         "phid": "PHID-DIFF-test",
         "review_task_id": "local instance",
-        "revision": 51,
     }
 
     # Check the issues in the backend

--- a/bot/tests/test_reporter_backend.py
+++ b/bot/tests/test_reporter_backend.py
@@ -129,4 +129,5 @@ def test_missing_bugzilla_id(
         "phid": "PHID-DREV-zzzzz",
         "repository": "test",
         "title": "Static Analysis tests",
+        "diffs_url": "http://code-review-backend.test/v1/revision/51/diffs/",
     }


### PR DESCRIPTION
This is the first step to migrate the frontend to use the new backend (see #187)

- List of detailed diff (with revision) in read only on `/v1/diff/`
- CRUD Diff per revision api on `/v1/revision/XXX/diffs`
- Fixes in the bot to support this api instead of the previous endpoint