### PR TITLE
frontend: Use directly issues analyzer & check

### DIFF
--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -147,31 +147,13 @@ export default new Vuex.Store({
       if (state.stats !== null && report.issues) {
         // Calc stats for this report
         state.stats.checks = report.issues.reduce((stats, issue) => {
-          var analyzer = issue.analyzer + (issue.analyzer === 'mozlint' ? '.' + issue.linter : '')
-          var check = null
-          if (issue.analyzer === 'clang-tidy') {
-            check = issue.check
-          } else if (issue.analyzer === 'clang-format') {
-            check = 'lint' // No check information on clang-format
-          } else if (issue.analyzer === 'infer') {
-            check = issue.bug_type
-          } else if (issue.analyzer === 'mozlint') {
-            check = issue.rule
-          } else if (issue.analyzer === 'Coverity') {
-            check = issue.kind
-          } else if (issue.analyzer === 'coverage') {
-            check = 'zero coverage'
-          } else {
-            console.warn('Unsupported analyzer', issue.analyzer)
-            return
-          }
-          var key = analyzer + '.' + check
+          var key = issue.analyzer + '.' + issue.check
           if (stats[key] === undefined) {
             stats[key] = {
-              analyzer: analyzer,
+              analyzer: issue.analyzer,
               key: key,
               message: issue.message,
-              check: check,
+              check: issue.check,
               publishable: 0,
               issues: [],
               total: 0

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -147,7 +147,7 @@ export default new Vuex.Store({
       if (state.stats !== null && report.issues) {
         // Calc stats for this report
         state.stats.checks = report.issues.reduce((stats, issue) => {
-          var key = issue.analyzer + '.' + issue.check
+          let key = issue.analyzer + '.' + issue.check
           if (stats[key] === undefined) {
             stats[key] = {
               analyzer: issue.analyzer,


### PR DESCRIPTION
Now that the bot outputs always the same payloads for Issues, the frontend does not need to clean them up !

![](https://i.imgur.com/UFrVsD6.png)