### PR TITLE
Support local configuration in the bot

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 known_first_party = code_review_backend,code_review_bot,code_review_tools,code_review_events,conftest
-known_third_party = dj_database_url,django,influxdb,libmozdata,libmozevent,logbook,parsepatch,pytest,raven,requests,responses,rest_framework,sentry_sdk,setuptools,structlog,taskcluster,toml
+known_third_party = dj_database_url,django,influxdb,libmozdata,libmozevent,logbook,parsepatch,pytest,raven,requests,responses,rest_framework,sentry_sdk,setuptools,structlog,taskcluster,toml,yaml
 force_single_line = True
 default_section=FIRSTPARTY
 line_length=159

--- a/bot/README.md
+++ b/bot/README.md
@@ -30,7 +30,7 @@ code-review-bot --configuration=path/to/config.yaml
 Configuration
 -------------
 
-The code review bot is configured through the [Taskcluster secrets service](https://firefox-ci-tc.services.mozilla.com/secrets) or a local YAML configuration file (the later is preferred for new contributors as it's easier to setup)
+The code review bot is configured through the [Taskcluster secrets service](https://firefox-ci-tc.services.mozilla.com/secrets) or a local YAML configuration file (the latter is preferred for new contributors as it's easier to setup)
 
 The following configuration variables are currently supported:
 

--- a/bot/README.md
+++ b/bot/README.md
@@ -19,7 +19,7 @@ flake8
 pytest
 ```
 
-If those tests are OK, you can run the bot locally, by specifying a Taskcluster secret with your configuration, and a task reference to analyze.
+If those tests are OK, you can run the bot locally, by using a local configuration file with your Phabricator API token (see details at the end of this READMe), and a task reference to analyze.
 
 ```
 export TRY_TASK_ID=XXX

--- a/bot/README.md
+++ b/bot/README.md
@@ -19,7 +19,7 @@ flake8
 pytest
 ```
 
-If those tests are OK, you can run the bot locally, by using a local configuration file with your Phabricator API token (see details at the end of this READMe), and a task reference to analyze.
+If those tests are OK, you can run the bot locally, by using a local configuration file with your Phabricator API token (see details at the end of this README), and a task reference to analyze.
 
 ```
 export TRY_TASK_ID=XXX

--- a/bot/README.md
+++ b/bot/README.md
@@ -24,13 +24,13 @@ If those tests are OK, you can run the bot locally, by specifying a Taskcluster 
 ```
 export TRY_TASK_ID=XXX
 export TRY_TASK_GROUP_ID=XXX
-code-review-bot --taskcluster-secret=path/to/secret
+code-review-bot --configuration=path/to/config.yaml
 ```
 
 Configuration
 -------------
 
-The code review bot is configured through the [Taskcluster secrets service](https://firefox-ci-tc.services.mozilla.com/secrets)
+The code review bot is configured through the [Taskcluster secrets service](https://firefox-ci-tc.services.mozilla.com/secrets) or a local YAML configuration file (the later is preferred for new contributors as it's easier to setup)
 
 The following configuration variables are currently supported:
 
@@ -76,38 +76,22 @@ Key `reporter` is `phabricator`
 
 Configuration:
 
- * `analyzers` : The analyzers that will be published on Phabricator. Possible values are: mozlint, clang-tidy, clang-format, coverity, infer, coverage.
+ * `analyzers_skipped` : The analyzers that will **not** be published on Phabricator.
 
 This reporter will send detailed information about every **publishable** issue.
 
 Example configuration
 ---------------------
 
-```json
-{
-  "common": {
-    "APP_CHANNEL": "staging",
-    "PAPERTRAIL_HOST": "XXXX.papertrail.net",
-    "PAPERTRAIL_PORT": 12345,
-    "PHABRICATOR": {
-      "url": "https://dev.phabricator.mozilla.com",
-      "api_key": "deadbeef123456"
-    }
-  },
-  "code-review-bot": {
-    "REPORTERS": [
-      {
-        "reporter": "mail",
-        "emails": [
-          "xxx@mozilla.com",
-          "yyy@mozilla.com"
-        ]
-      },
-      {
-        "reporter": "phabricator",
-        "analyzers": ["clang-tidy", "mozlint"]
-      }
-    ]
-  }
-}
+```yaml
+---
+common:
+  APP_CHANNEL: development
+  PHABRICATOR:
+    url: https://dev.phabricator.mozilla.com
+    api_key: deadbeef123456
+
+code-review-bot:
+  REPORTERS:
+  - reporter: phabricator
 ```

--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -30,6 +30,12 @@ def parse_cli():
     """
     parser = argparse.ArgumentParser(description="Mozilla Code Review Bot")
     parser.add_argument(
+        "-c",
+        "--configuration",
+        help="Local configuration file replacing Taskcluster secrets",
+        type=open,
+    )
+    parser.add_argument(
         "--taskcluster-secret",
         help="Taskcluster Secret path",
         default=os.environ.get("TASKCLUSTER_SECRET"),
@@ -55,6 +61,7 @@ def main():
             "ZERO_COVERAGE_ENABLED": True,
             "ALLOWED_PATHS": ["*"],
         },
+        local_source=args.configuration,
     )
 
     init_logger(

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,5 @@
 Logbook==1.5.3
+pyyaml==5.1.2
 structlog==19.2.0
 taskcluster==22.1.1
 toml==0.10.0


### PR DESCRIPTION
The backend does not need it, as it can already run without a Taskcluster client.
The events use libmozevent TaskclusterConfig...

Refs #234 