### PR TITLE
Support missing bugzilla id in phabricator data

### DIFF
--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -355,7 +355,7 @@ class Revision(object):
     def bugzilla_id(self):
         try:
             return int(self.revision["fields"].get("bugzilla.bug-id"))
-        except ValueError:
+        except (TypeError, ValueError):
             logger.info("No bugzilla id available for this revision")
             return None
 

--- a/bot/tests/test_revisions.py
+++ b/bot/tests/test_revisions.py
@@ -133,3 +133,22 @@ index 83db48f8..84275f99 100644
     assert mock_revision.contains(issue_in_existing_file_added_line)
     assert not mock_revision.contains(issue_in_not_changed_file)
     assert mock_revision.contains(issue_full_file)
+
+
+def test_bugzilla_id(mock_revision):
+    """Test the bugzilla id parsing from phabricator data"""
+
+    # Default value from mock
+    assert mock_revision.bugzilla_id == 1234567
+
+    # Update phabricator data on revision
+    mock_revision.revision["fields"]["bugzilla.bug-id"] = "456789"
+    assert mock_revision.bugzilla_id == 456789
+
+    # On bad data fallback gracefully
+    mock_revision.revision["fields"]["bugzilla.bug-id"] = "notaBZid"
+    assert mock_revision.bugzilla_id is None
+
+    # On missing data fallback gracefully
+    del mock_revision.revision["fields"]["bugzilla.bug-id"]
+    assert mock_revision.bugzilla_id is None


### PR DESCRIPTION
Phabricator does not always have that information (missing properties)