### PR TITLE
Use events docker image on Heroku workers too

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -349,6 +349,7 @@ tasks:
             - --heroku-app
             - "code-review-events-${channel}"
             - web:public/code-review-events.tar
+            - worker:public/code-review-events.tar
           env:
             TASKCLUSTER_SECRET: "project/relman/code-review/deploy-${channel}"
         scopes:


### PR DESCRIPTION
Yesterday i had to ship manually the current production docker image on Heroku workers, as they do not use automatically the same image than the web workers.

This patch automatically updates both worker types, even if we do not always use them.