### PR TITLE
tools: Update deps limits

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,5 +5,5 @@ taskcluster==23.0.0
 toml==0.10.0
 raven==6.10.0
 
-# limit async-timeout version to avoid using the alpha 4.0.0a0
-async-timeout<4.0,>=3.0
+# limit multidict to avoid building with gcc on alpine
+multidict<4.6.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,5 +5,9 @@ taskcluster==23.0.0
 toml==0.10.0
 raven==6.10.0
 
+# limit async-timeout version to avoid using the alpha 4.0.0a0
+# still breaking the events build
+async-timeout<4.0,>=3.0
+
 # limit multidict to avoid building with gcc on alpine
 multidict<4.6.0


### PR DESCRIPTION
A new `python:3.7-alpine` was released that [breaks building a dependency](https://community-tc.services.mozilla.com/tasks/Esj8VQ3ETCKA_aH84L5jnw/runs/0/logs/https%3A%2F%2Fcommunity-tc.services.mozilla.com%2Fapi%2Fqueue%2Fv1%2Ftask%2FEsj8VQ3ETCKA_aH84L5jnw%2Fruns%2F0%2Fartifacts%2Fpublic%2Flogs%2Flive.log) 