### PR TITLE
events: Don't register for pulse notifications when publication is disabled

### DIFF
--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -301,14 +301,15 @@ class Events(object):
         self.monitoring.register(self.bus)
 
         # Create pulse listener for unit test failures
-        self.pulse = PulseListener(
-            QUEUE_PULSE,
-            "exchange/taskcluster-queue/v1/task-completed",
-            "*.*.gecko-level-3._",
-            taskcluster_config.secrets["pulse_user"],
-            taskcluster_config.secrets["pulse_password"],
-        )
-        self.pulse.register(self.bus)
+        if self.workflow.publish:
+            self.pulse = PulseListener(
+                QUEUE_PULSE,
+                "exchange/taskcluster-queue/v1/task-completed",
+                "*.*.gecko-level-3._",
+                taskcluster_config.secrets["pulse_user"],
+                taskcluster_config.secrets["pulse_password"],
+            )
+            self.pulse.register(self.bus)
 
     def run(self):
         consumers = [

--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -319,8 +319,6 @@ class Events(object):
             self.mercurial.run(),
             # Add monitoring task
             self.monitoring.run(),
-            # Add pulse task
-            self.pulse.run(),
         ]
 
         # Publish results on Phabricator
@@ -329,6 +327,7 @@ class Events(object):
                 self.bus.run(self.workflow.publish_results, QUEUE_PHABRICATOR_RESULTS)
             )
 
+            consumers.append(self.pulse.run())
             consumers.append(self.bus.run(self.workflow.parse_pulse, QUEUE_PULSE))
 
         # Start the web server in its own process


### PR DESCRIPTION
Since we don't consume messages when publication is disabled: https://github.com/mozilla/code-review/blob/02d31adcbb878d50fb7f8846ae6d29150178bea0/events/code_review_events/workflow.py#L356-L362.