### PR TITLE
Cleanup revision creation

### DIFF
--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -101,11 +101,8 @@ def main():
 
     # Load unique revision
     try:
-        revision = Revision(
-            phabricator_api,
-            try_task=queue_service.task(settings.try_task_id),
-            # Update build status only when phabricator reporting is enabled
-            update_build=phabricator_reporting_enabled,
+        revision = Revision.from_try(
+            queue_service.task(settings.try_task_id), phabricator_api
         )
     except Exception as e:
         # Report revision loading failure on production only

--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -167,9 +167,10 @@ class PhabricatorReporter(Reporter):
         """
         Publish issues through HarborMaster
         """
-        revision.update_status(
+        self.api.update_build_target(
+            revision.build_target_phid,
             state=BuildState.Work,
-            lint_issues=[issue.as_phabricator_lint() for issue in issues],
+            lint=[issue.as_phabricator_lint() for issue in issues],
         )
 
     def comment_inline(self, revision, issue, existing_comments=[]):

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 
 import requests
 import structlog
-from libmozdata.phabricator import BuildState
 from libmozdata.phabricator import PhabricatorAPI
 from parsepatch.patch import Patch
 
@@ -73,7 +72,7 @@ class Revision(object):
     A Phabricator revision to analyze and report on
     """
 
-    def __init__(self, api, try_task, update_build=True):
+    def __init__(self, api, try_task):
         assert isinstance(api, PhabricatorAPI)
         assert isinstance(try_task, dict)
         self.repository = None  # a try repo where the revision is stored
@@ -86,7 +85,6 @@ class Revision(object):
         self.build_target_phid = None
         self.api = api
         self.mercurial_revision = None
-        self.update_build = update_build
         self.issues_url = None
         self.load_phabricator(try_task)
 
@@ -293,27 +291,6 @@ class Revision(object):
         * improvement patches
         """
         self.improvement_patches = []
-
-    def update_status(self, state, lint_issues=[]):
-        """
-        Update build status on HarborMaster
-        """
-        assert isinstance(state, BuildState)
-        assert isinstance(lint_issues, list)
-        if not self.build_target_phid:
-            logger.info(
-                "No build target found, skipping HarborMaster update", state=state.value
-            )
-            return
-
-        if not self.update_build:
-            logger.info(
-                "Update build disabled, skipping HarborMaster update", state=state.value
-            )
-            return
-
-        self.api.update_build_target(self.build_target_phid, state, lint=lint_issues)
-        logger.info("Updated HarborMaster status", state=state)
 
     def setup_try(self, tasks):
         """

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -132,12 +132,10 @@ class Revision(object):
         return "Phabricator #{} - {}".format(self.diff_id, self.diff_phid)
 
     @staticmethod
-    def from_try(try_task, phabricator):
+    def from_try(try_task: dict, phabricator: PhabricatorAPI):
         """
         Load identifiers from Phabricator, using the remote task description
         """
-        assert isinstance(phabricator, PhabricatorAPI)
-        assert isinstance(try_task, dict)
 
         # Load build target phid from the task env
         code_review = try_task["extra"]["code-review"]

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -209,7 +209,7 @@ def mock_revision(mock_phabricator, mock_try_task, mock_config):
     from code_review_bot.revisions import Revision
 
     with mock_phabricator as api:
-        return Revision(api, mock_try_task, update_build=False)
+        return Revision(api, mock_try_task)
 
 
 class MockQueue(object):
@@ -384,6 +384,7 @@ def mock_workflow(mock_phabricator, mock_taskcluster_config):
             self.queue_service = mock_taskcluster_config.get_service("queue")
             self.zero_coverage_enabled = True
             self.backend_api = BackendAPI()
+            self.update_build = False
 
         def setup_mock_tasks(self, tasks):
             """

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -209,7 +209,7 @@ def mock_revision(mock_phabricator, mock_try_task, mock_config):
     from code_review_bot.revisions import Revision
 
     with mock_phabricator as api:
-        return Revision(api, mock_try_task)
+        return Revision.from_try(mock_try_task, api)
 
 
 class MockQueue(object):

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -98,7 +98,7 @@ def test_phabricator_clang_tidy(mock_phabricator, mock_try_task):
     )
 
     with mock_phabricator as api:
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         revision.lines = {
             # Add dummy lines diff
             "another_test.cpp": [41, 42, 43]
@@ -164,7 +164,7 @@ def test_phabricator_clang_format(mock_config, mock_phabricator, mock_try_task):
     )
 
     with mock_phabricator as api:
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         revision.lines = {
             # Add dummy lines diff
             "test.cpp": [41, 42, 43],
@@ -222,7 +222,7 @@ def test_phabricator_coverage(mock_config, mock_phabricator, mock_try_task):
     )
 
     with mock_phabricator as api:
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         revision.lines = {
             # Add dummy lines diff
             "test.txt": [0],
@@ -306,7 +306,7 @@ def test_phabricator_clang_tidy_and_coverage(
     )
 
     with mock_phabricator as api:
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         revision.lines = {
             # Add dummy lines diff
             "test.txt": [0],
@@ -366,7 +366,7 @@ def test_phabricator_analyzers(mock_config, mock_phabricator, mock_try_task):
 
     def _test_reporter(api, analyzers_skipped):
         # Always use the same setup, only varies the analyzers
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         revision.lines = {"test.cpp": [0, 41, 42, 43], "dom/test.cpp": [42]}
         reporter = PhabricatorReporter(
             {"analyzers_skipped": analyzers_skipped}, api=api
@@ -532,7 +532,7 @@ def test_phabricator_harbormaster(mock_phabricator, mock_try_task):
     )
 
     with mock_phabricator as api:
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         revision.lines = {
             # Add dummy lines diff
             "test.cpp": [41, 42, 43]
@@ -640,7 +640,7 @@ def test_phabricator_unitresult(mock_phabricator, mock_try_task):
     )
 
     with mock_phabricator as api:
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         revision.lines = {
             # Add dummy lines diff
             "test.cpp": [41, 42, 43]
@@ -765,7 +765,7 @@ def test_full_file(mock_config, mock_phabricator, mock_try_task):
     )
 
     with mock_phabricator as api:
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         revision.lines = {
             # Add dummy lines diff
             "xx.cpp": [123, 124, 125]
@@ -840,7 +840,7 @@ def test_task_failures(mock_phabricator, mock_try_task):
     )
 
     with mock_phabricator as api:
-        revision = Revision(api, mock_try_task)
+        revision = Revision.from_try(mock_try_task, api)
         reporter = PhabricatorReporter(
             {"analyzers": ["clang-tidy"], "modes": ("comment")}, api=api
         )


### PR DESCRIPTION
- Removes dependency on `PhabricatorAPI` in the constructor
- Explicitly create a revision from a try task + phabricator api

Preparation work for #211 to be able to create `Revision` from an autoland decision task payload