### PR TITLE
Fix libmozevent 1.0.9 pulse usage

### DIFF
--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -318,8 +318,12 @@ class Events(object):
             if publish:
                 self.pulse = PulseListener(
                     QUEUE_PULSE,
-                    "exchange/taskcluster-queue/v1/task-completed",
-                    "*.*.gecko-level-3._",
+                    [
+                        (
+                            "exchange/taskcluster-queue/v1/task-completed",
+                            ["*.*.gecko-level-3._"],
+                        )
+                    ],
                     taskcluster_config.secrets["pulse_user"],
                     taskcluster_config.secrets["pulse_password"],
                 )


### PR DESCRIPTION
Needed to run the current code on Heroku testing.
Otherwise we send invalid parameters on Pulse, leading to an `AmqpClosedConnection`