### PR TITLE
Use repository urls instead of assuming slugs

### DIFF
--- a/backend/code_review_backend/issues/serializers.py
+++ b/backend/code_review_backend/issues/serializers.py
@@ -27,7 +27,7 @@ class RevisionSerializer(serializers.ModelSerializer):
     """
 
     repository = serializers.SlugRelatedField(
-        queryset=Repository.objects.all(), slug_field="slug"
+        queryset=Repository.objects.all(), slug_field="url"
     )
     diffs_url = serializers.HyperlinkedIdentityField(
         view_name="revision-diffs-list", lookup_url_kwarg="revision_id"
@@ -54,7 +54,7 @@ class DiffSerializer(serializers.ModelSerializer):
     """
 
     repository = serializers.SlugRelatedField(
-        queryset=Repository.objects.all(), slug_field="slug"
+        queryset=Repository.objects.all(), slug_field="url"
     )
     issues_url = serializers.HyperlinkedIdentityField(
         view_name="issues-list", lookup_url_kwarg="diff_id"

--- a/backend/code_review_backend/issues/tests/test_api.py
+++ b/backend/code_review_backend/issues/tests/test_api.py
@@ -35,7 +35,7 @@ class CreationAPITestCase(APITestCase):
             "phid": "PHID-REV-xxx",
             "title": "Bug XXX - Some bug",
             "bugzilla_id": 123456,
-            "repository": "myrepo",
+            "repository": "http://repo.test/myrepo",
         }
 
         # No auth will give a permission denied
@@ -63,7 +63,7 @@ class CreationAPITestCase(APITestCase):
             "phid": "PHID-DIFF-xxx",
             "review_task_id": "deadbeef123",
             "mercurial_hash": "coffee12345",
-            "repository": "try",
+            "repository": "http://repo.test/try",
         }
 
         # No auth will give a permission denied

--- a/backend/code_review_backend/issues/tests/test_diff.py
+++ b/backend/code_review_backend/issues/tests/test_diff.py
@@ -68,7 +68,7 @@ class DiffAPITestCase(APITestCase):
                         "id": 3,
                         "revision": {
                             "id": 1,
-                            "repository": "myrepo",
+                            "repository": "http://repo.test/myrepo",
                             "phid": "PHID-DREV-1",
                             "title": "Revision 1",
                             "bugzilla_id": 10000,
@@ -93,7 +93,7 @@ class DiffAPITestCase(APITestCase):
                         "id": 2,
                         "revision": {
                             "id": 2,
-                            "repository": "myrepo",
+                            "repository": "http://repo.test/myrepo",
                             "phid": "PHID-DREV-2",
                             "title": "Revision 2",
                             "bugzilla_id": 10001,
@@ -118,7 +118,7 @@ class DiffAPITestCase(APITestCase):
                         "id": 1,
                         "revision": {
                             "id": 1,
-                            "repository": "myrepo",
+                            "repository": "http://repo.test/myrepo",
                             "phid": "PHID-DREV-1",
                             "title": "Revision 1",
                             "bugzilla_id": 10000,

--- a/bot/code_review_bot/backend.py
+++ b/bot/code_review_bot/backend.py
@@ -45,6 +45,12 @@ class BackendAPI(object):
             logger.warn("Skipping revision publication on backend")
             return
 
+        # Check the repositories are urls
+        for url in (revision.target_repository, revision.repository):
+            assert isinstance(url, str), "Repository must be a string"
+            res = urllib.parse.urlparse(url)
+            assert res.scheme and res.netloc, f"Repository {url} is not an url"
+
         # Create revision on backend if it does not exists
         data = {
             "id": revision.id,

--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -16,9 +16,6 @@ import tempfile
 import structlog
 
 PROJECT_NAME = "code-review-bot"
-REPO_GECKO_TRY = "https://hg.mozilla.org/try"
-REPO_NSS_TRY = "https://hg.mozilla.org/projects/nss-try"
-RAW_FILE_URL = "https://hg.mozilla.org/mozilla-central/raw-file/tip/{}"
 
 logger = structlog.get_logger(__name__)
 

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -14,8 +14,6 @@ from parsepatch.patch import Patch
 
 from code_review_bot import Issue
 from code_review_bot import stats
-from code_review_bot.config import REPO_GECKO_TRY
-from code_review_bot.config import REPO_NSS_TRY
 from code_review_bot.config import settings
 from code_review_tools.taskcluster import create_blob_artifact
 
@@ -348,17 +346,20 @@ class Revision(object):
 
         # Use mercurial infos for local revision
         decision_env = decision_task["task"]["payload"]["env"]
-        if decision_env.get("GECKO_HEAD_REPOSITORY") == REPO_GECKO_TRY:
+        if "GECKO_HEAD_REPOSITORY" in decision_env:
             # Mozilla-Central Try
             self.mercurial_revision = decision_env.get("GECKO_HEAD_REV")
-            self.repository = "try"
-            self.target_repository = "mozilla-central"
+            self.repository = decision_env["GECKO_HEAD_REPOSITORY"]
+            # mozilla-unified is used in the Decision task payload
+            # but that is not the "real" target repository
+            self.target_repository = "https://hg.mozilla.org/mozilla-central"
 
-        elif decision_env.get("NSS_HEAD_REPOSITORY") == REPO_NSS_TRY:
+        elif "NSS_HEAD_REPOSITORY" in decision_env:
             # NSS Try
             self.mercurial_revision = decision_env.get("NSS_HEAD_REVISION")
-            self.repository = "nss-try"
-            self.target_repository = "nss"
+            self.repository = decision_env["NSS_HEAD_REPOSITORY"]
+            # Unfortunately the NSS decision task does not expose the target repository
+            self.target_repository = "https://hg.mozilla.org/projects/nss"
 
         else:
             raise Exception("Unsupported decision task")

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -454,7 +454,7 @@ def mock_hgmo():
 
     responses.add_callback(
         responses.GET,
-        re.compile(r"^https://hg.mozilla.org/[\w-]+/raw-file/.*"),
+        re.compile(r"^https?://(hgmo|hg\.mozilla\.org)/[\w-]+/raw-file/.*"),
         callback=fake_raw_file,
     )
 

--- a/bot/tests/test_reporter_debug.py
+++ b/bot/tests/test_reporter_debug.py
@@ -60,8 +60,8 @@ def test_publication(tmpdir, mock_issues, mock_revision):
         "phid": "PHID-DREV-zzzzz",
         "title": "Static Analysis tests",
         "has_clang_files": False,
-        "repository": "try",
-        "target_repository": "mozilla-central",
+        "repository": "https://hg.mozilla.org/try",
+        "target_repository": "https://hg.mozilla.org/mozilla-central",
         "mercurial_revision": "deadc0ffee",
     }
 


### PR DESCRIPTION
So we don't have to maintain lists of slugs, and can use any repository (even Github).