### PR TITLE
events: Fix bugbug utils setup call

### DIFF
--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -419,7 +419,7 @@ class Events(object):
             ]
 
         if self.bugbug_utils:
-            consumers_setup.append(self.bugbug_utils.setup),
+            consumers_setup.append(self.bugbug_utils.setup()),
             consumers += [
                 self.bus.run(
                     self.bugbug_utils.process_build, QUEUE_BUGBUG, sequential=False


### PR DESCRIPTION
Otherwise we get an exception:

```
2019-12-09T10:52:38.406540+00:00 app[worker.1]: 2019-12-09 10:52:38.382754 [ERROR   ] libmozevent.utils: Failure while running async tasks (error='An asyncio.Future, a coroutine or an awaitable is required')
2019-12-09T10:52:38.963512+00:00 app[worker.1]: Traceback (most recent call last):
2019-12-09T10:52:38.963531+00:00 app[worker.1]:   File "/usr/local/lib/python3.7/site-packages/libmozevent-1.1.0-py3.7.egg/libmozevent/utils.py", line 49, in _run
2019-12-09T10:52:38.963533+00:00 app[worker.1]:     task = asyncio.gather(*awaitables)
2019-12-09T10:52:38.963540+00:00 app[worker.1]:   File "/usr/local/lib/python3.7/asyncio/tasks.py", line 746, in gather
2019-12-09T10:52:38.963542+00:00 app[worker.1]:     fut = ensure_future(arg, loop=loop)
2019-12-09T10:52:38.963544+00:00 app[worker.1]:   File "/usr/local/lib/python3.7/asyncio/tasks.py", line 619, in ensure_future
2019-12-09T10:52:38.963546+00:00 app[worker.1]:     raise TypeError('An asyncio.Future, a coroutine or an awaitable is '
2019-12-09T10:52:38.963548+00:00 app[worker.1]: TypeError: An asyncio.Future, a coroutine or an awaitable is required
2019-12-09T10:52:38.963550+00:00 app[worker.1]: 
2019-12-09T10:52:38.963553+00:00 app[worker.1]: During handling of the above exception, another exception occurred:
2019-12-09T10:52:38.963555+00:00 app[worker.1]: 
2019-12-09T10:52:38.963557+00:00 app[worker.1]: Traceback (most recent call last):
2019-12-09T10:52:38.963559+00:00 app[worker.1]:   File "/usr/local/bin/code-review-events", line 11, in <module>
2019-12-09T10:52:38.963561+00:00 app[worker.1]:     load_entry_point('code-review-events==1.1.0', 'console_scripts', 'code-review-events')()
2019-12-09T10:52:38.963563+00:00 app[worker.1]:   File "/usr/local/lib/python3.7/site-packages/code_review_events-1.1.0-py3.7.egg/code_review_events/cli.py", line 77, in main
2019-12-09T10:52:38.963568+00:00 app[worker.1]:     events.run()
2019-12-09T10:52:38.963571+00:00 app[worker.1]:   File "/usr/local/lib/python3.7/site-packages/code_review_events-1.1.0-py3.7.egg/code_review_events/workflow.py", line 469, in run
2019-12-09T10:52:38.963573+00:00 app[worker.1]:     run_tasks(consumers_setup)
2019-12-09T10:52:38.963575+00:00 app[worker.1]:   File "/usr/local/lib/python3.7/site-packages/libmozevent-1.1.0-py3.7.egg/libmozevent/utils.py", line 59, in run_tasks
2019-12-09T10:52:38.963577+00:00 app[worker.1]:     event_loop.run_until_complete(_run())
2019-12-09T10:52:38.963579+00:00 app[worker.1]:   File "/usr/local/lib/python3.7/asyncio/base_events.py", line 579, in run_until_complete
2019-12-09T10:52:38.963581+00:00 app[worker.1]:     return future.result()
2019-12-09T10:52:38.963583+00:00 app[worker.1]:   File "/usr/local/lib/python3.7/site-packages/libmozevent-1.1.0-py3.7.egg/libmozevent/utils.py", line 56, in _run
2019-12-09T10:52:38.963586+00:00 app[worker.1]:     task.cancel()
2019-12-09T10:52:38.963588+00:00 app[worker.1]: UnboundLocalError: local variable 'task' referenced before assignment```