### PR TITLE
events: publish_results should be async in order to use parallel bus processing

### DIFF
--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -144,7 +144,7 @@ class CodeReview(PhabricatorActions):
         )
         return True
 
-    def publish_results(self, payload):
+    async def publish_results(self, payload):
         if not self.publish:
             logger.debug("Skipping Phabricator publication")
             return

--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -205,8 +205,6 @@ class CodeReview(PhabricatorActions):
         else:
             logger.warning("Unsupported publication", mode=mode, build=build)
 
-        return True
-
     async def trigger_autoland(self, payload: dict):
         """
         Trigger a code review autoland ingestion task


### PR DESCRIPTION
Since I was here, I've also removed a `return True` which is no longer needed in newer releases of libmozevent.