### PR TITLE
Load enabled reviewers just once at startup

### DIFF
--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -110,9 +110,6 @@ class CodeReview(PhabricatorActions):
             try:
                 self.load_patches_stack(build)
                 logger.info("Loaded stack of patches", build=str(build))
-
-                self.load_reviewers(build)
-                logger.info("Loaded reviewers", build=str(build))
             except Exception as e:
                 logger.warning(
                     "Failed to load build details", build=str(build), error=str(e)
@@ -379,7 +376,7 @@ class Events(object):
             else:
                 self.community_monitoring = None
 
-            self.bugbug_utils = BugbugUtils()
+            self.bugbug_utils = BugbugUtils(self.workflow.api)
             self.bugbug_utils.register(self.bus)
         else:
             self.workflow = None

--- a/events/tests/fixtures/phabricator/user-search-ehsan-heycam.json
+++ b/events/tests/fixtures/phabricator/user-search-ehsan-heycam.json
@@ -1,0 +1,59 @@
+{
+	"result": {
+		"data": [{
+				"id": 310,
+				"type": "USER",
+				"phid": "PHID-USER-b7hdnyyixwg3ryznhyb7",
+				"fields": {
+					"username": "Ehsan",
+					"realName": "Ehsan Akhgari",
+					"roles": [
+						"verified",
+						"approved",
+						"activated"
+					],
+					"dateCreated": 1532388613,
+					"dateModified": 1566603035,
+					"policy": {
+						"view": "public",
+						"edit": "no-one"
+					}
+				},
+				"attachments": {}
+			},
+			{
+				"id": 50,
+				"type": "USER",
+				"phid": "PHID-USER-ciaomkrkqpbwfmdqahdu",
+				"fields": {
+					"username": "heycam",
+					"realName": "Cameron McCormack",
+					"roles": [
+						"verified",
+						"approved",
+						"activated"
+					],
+					"dateCreated": 1507533578,
+					"dateModified": 1573019467,
+					"policy": {
+						"view": "public",
+						"edit": "no-one"
+					}
+				},
+				"attachments": {}
+			}
+		],
+		"maps": {},
+		"query": {
+			"queryKey": null
+		},
+		"cursor": {
+			"limit": 100,
+			"after": null,
+			"before": null,
+			"order": null
+		}
+	},
+	"error_code": null,
+	"error_info": null
+}

--- a/events/tests/fixtures/phabricator/user-search-ehsan.json
+++ b/events/tests/fixtures/phabricator/user-search-ehsan.json
@@ -1,0 +1,37 @@
+{
+	"result": {
+		"data": [{
+			"id": 310,
+			"type": "USER",
+			"phid": "PHID-USER-b7hdnyyixwg3ryznhyb7",
+			"fields": {
+				"username": "Ehsan",
+				"realName": "Ehsan Akhgari",
+				"roles": [
+					"verified",
+					"approved",
+					"activated"
+				],
+				"dateCreated": 1532388613,
+				"dateModified": 1566603035,
+				"policy": {
+					"view": "public",
+					"edit": "no-one"
+				}
+			},
+			"attachments": {}
+		}],
+		"maps": {},
+		"query": {
+			"queryKey": null
+		},
+		"cursor": {
+			"limit": 100,
+			"after": null,
+			"before": null,
+			"order": null
+		}
+	},
+	"error_code": null,
+	"error_info": null
+}


### PR DESCRIPTION
This way we can avoid loading reviewers from Phabricator for each diff.