### PR TITLE
Workaround to get parsepatch to run on alpine

### DIFF
--- a/backend/code_review_backend/issues/management/commands/load_in_patch.py
+++ b/backend/code_review_backend/issues/management/commands/load_in_patch.py
@@ -36,7 +36,7 @@ def load_hgmo_patch(diff):
     resp = requests.get(url)
     resp.raise_for_status()
 
-    patch = Patch.parse_patch(resp.content, skip_comments=False)
+    patch = Patch.parse_patch(resp.text, skip_comments=False)
     assert patch != {}, "Empty patch"
     lines = {
         # Use all changes in new files


### PR DESCRIPTION
Followup of #398 

Reported upstream on https://github.com/mozilla/parsepatch/issues/11