### PR TITLE
Dedicated Postgresql connection on each process

### DIFF
--- a/backend/code_review_backend/app/settings.py
+++ b/backend/code_review_backend/app/settings.py
@@ -100,7 +100,9 @@ if "DATABASE_URL" in os.environ:
     logger.info("Using remote database from $DATABASE_URL")
     DATABASES = {
         "default": dj_database_url.parse(
-            os.environ["DATABASE_URL"], ssl_require="DYNO" in os.environ
+            os.environ["DATABASE_URL"],
+            conn_max_age=600,
+            ssl_require="DYNO" in os.environ,
         )
     }
 else:

--- a/backend/code_review_backend/issues/management/commands/load_in_patch.py
+++ b/backend/code_review_backend/issues/management/commands/load_in_patch.py
@@ -7,6 +7,7 @@ import logging
 from multiprocessing import Pool
 
 import requests
+from django import db
 from django.core.management.base import BaseCommand
 from parsepatch.patch import Patch
 
@@ -99,6 +100,9 @@ class Command(BaseCommand):
             Diff.objects.filter(issues__in_patch__isnull=True).order_by("id").distinct()
         )
         logger.debug("Will process {} diffs".format(diffs.count()))
+
+        # Close all DB connection so each process get its own
+        db.connections.close_all()
 
         # Process all the diffs in parallel
         with Pool(processes=options["nb_processes"]) as pool:


### PR DESCRIPTION
Another issue found on testing, the postgresql connection does not work in a multiprocessing context (whereas with sqlite in dev it works).

So i need to close all pre-existing connections before starting the processes, so that each process gets its own connection.