### PR TITLE
Issues from treeherder tier 1 are always errors

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -69,6 +69,7 @@ class Issue(abc.ABC):
         from code_review_bot.revisions import Revision
 
         assert isinstance(revision, Revision)
+        assert isinstance(level, Level)
 
         # Base required fields for all issues
         assert not os.path.isabs(path), f"Issue path can not be absolute {path}"
@@ -79,6 +80,7 @@ class Issue(abc.ABC):
         self.line = positive_int("line", line)
         self.nb_lines = positive_int("nb_lines", nb_lines)
         self.check = check
+        self.level = level
 
         # Support line 0, with a Sentry warning
         if self.line == 0:
@@ -88,7 +90,6 @@ class Issue(abc.ABC):
         # Optional common fields
         self.column = column
         self.message = message
-        self.level = level
 
         # Reserved payload for backend
         self.on_backend = None

--- a/bot/code_review_bot/tasks/clang_tidy.py
+++ b/bot/code_review_bot/tasks/clang_tidy.py
@@ -61,6 +61,7 @@ class ClangTidyIssue(Issue):
         reliability=Reliability.Unknown,
         reason=None,
         publish=True,
+        level=Level.Warning,
     ):
         assert isinstance(reliability, Reliability)
 
@@ -72,7 +73,7 @@ class ClangTidyIssue(Issue):
             nb_lines=1,  # Only 1 line affected on clang-tidy
             check=check,
             column=int(column),
-            level=Level.Warning,
+            level=level,
             message=message,
         )
         self.notes = []
@@ -193,6 +194,7 @@ class ClangTidyTask(AnalysisTask):
                 else Reliability.Unknown,
                 reason=warning.get("reason"),
                 publish=warning.get("publish"),
+                level=self.get_issue_level(Level.Warning),
             )
             for artifact in artifacts.values()
             for path, items in artifact["files"].items()

--- a/bot/code_review_bot/tasks/coverity.py
+++ b/bot/code_review_bot/tasks/coverity.py
@@ -47,7 +47,7 @@ class CoverityIssue(Issue):
     An issue reported by coverity
     """
 
-    def __init__(self, analyzer, revision, issue, file_path):
+    def __init__(self, analyzer, revision, issue, file_path, level=Level.Warning):
         super().__init__(
             analyzer,
             revision,
@@ -55,7 +55,7 @@ class CoverityIssue(Issue):
             line=issue["line"],
             nb_lines=1,
             check=issue["flag"],
-            level=Level.Warning,
+            level=level,
             message=issue["message"],
         )
         self.reliability = (
@@ -198,7 +198,11 @@ class CoverityTask(AnalysisTask):
         assert isinstance(artifacts, dict)
         return [
             CoverityIssue(
-                analyzer=self.name, revision=revision, issue=warning, file_path=path
+                analyzer=self.name,
+                revision=revision,
+                issue=warning,
+                file_path=path,
+                level=self.get_issue_level(Level.Warning),
             )
             for artifact in artifacts.values()
             for path, items in artifact["files"].items()

--- a/bot/code_review_bot/tasks/default.py
+++ b/bot/code_review_bot/tasks/default.py
@@ -98,7 +98,7 @@ class DefaultTask(AnalysisTask):
                 line=issue["line"],
                 column=issue["column"],
                 nb_lines=issue.get("nb_lines", 1),
-                level=Level(issue["level"]),
+                level=self.get_issue_level(Level(issue["level"])),
                 check=default_check(issue),
                 message=issue["message"],
             )

--- a/bot/code_review_bot/tasks/infer.py
+++ b/bot/code_review_bot/tasks/infer.py
@@ -37,7 +37,7 @@ class InferIssue(Issue):
     An issue reported by infer
     """
 
-    def __init__(self, analyzer, entry, revision):
+    def __init__(self, analyzer, entry, revision, level=Level.Warning):
         assert isinstance(entry, dict)
         kind = entry.get("kind") or entry.get("severity")
         assert kind is not None, "Missing issue kind"
@@ -49,7 +49,7 @@ class InferIssue(Issue):
             nb_lines=1,
             check=entry["bug_type"],
             column=entry["column"],
-            level=Level.Warning,
+            level=level,
             message=entry["qualifier"],
         )
 
@@ -105,7 +105,12 @@ class InferTask(AnalysisTask):
         """
         assert isinstance(artifacts, dict)
         return [
-            InferIssue(analyzer=self.name, revision=revision, entry=issue)
+            InferIssue(
+                analyzer=self.name,
+                revision=revision,
+                entry=issue,
+                level=self.get_issue_level(Level.Warning),
+            )
             for issues in artifacts.values()
             for issue in issues
         ]

--- a/bot/code_review_bot/tasks/lint.py
+++ b/bot/code_review_bot/tasks/lint.py
@@ -51,7 +51,7 @@ class MozLintIssue(Issue):
             nb_lines=1,
             check=check,
             column=column,
-            level=Level(level),
+            level=level,
             message=message,
         )
         self.linter = linter
@@ -141,7 +141,7 @@ class MozLintTask(AnalysisTask):
                 revision=revision,
                 path=issue.get("relpath", issue["path"]),
                 column=issue["column"],
-                level=issue["level"],
+                level=self.get_issue_level(Level(issue["level"])),
                 lineno=issue["lineno"],
                 linter=issue["linter"],
                 message=issue["message"],

--- a/bot/tests/fixtures/mozlint_warnings.json
+++ b/bot/tests/fixtures/mozlint_warnings.json
@@ -1,0 +1,32 @@
+{
+    "fake/file.py": [
+        {
+            "rule": "rule-AAA",
+            "linter": "dummy-lint",
+            "column": null,
+            "lineoffset": null,
+            "lineno": 12,
+            "path": "fake/file.py",
+            "relpath": "fake/file.py",
+            "level": "warning",
+            "diff": null,
+            "source": null,
+            "hint": null,
+            "message": "Somme dummy warning for unit test"
+        },
+        {
+            "rule": "rule-XXX",
+            "linter": "dummy-lint",
+            "column": null,
+            "lineoffset": null,
+            "lineno": 42,
+            "path": "fake/file.py",
+            "relpath": "fake/file.py",
+            "level": "warning",
+            "diff": null,
+            "source": null,
+            "hint": null,
+            "message": "Somme other dummy warning for unit test"
+        }
+    ]
+}

--- a/bot/tests/test_hash.py
+++ b/bot/tests/test_hash.py
@@ -5,6 +5,7 @@
 
 import hashlib
 
+from code_review_bot import Level
 from code_review_bot.tasks.lint import MozLintIssue
 
 
@@ -20,7 +21,7 @@ def test_build_hash(mock_revision, mock_hgmo):
         "mock-analyzer-eslint",
         "path/to/file.cpp",
         42,
-        "error",
+        Level.Error,
         123,
         "eslint",
         "A random & fake linting issue",
@@ -57,7 +58,7 @@ def test_indentation_effect(mock_revision, mock_hgmo):
         "mock-analyzer-flake8",
         "hello1",
         2,
-        "error",
+        Level.Error,
         1,
         "flake8",
         "A random & fake linting issue",
@@ -68,7 +69,7 @@ def test_indentation_effect(mock_revision, mock_hgmo):
         "mock-analyzer-flake8",
         "hello1",
         5,
-        "error",
+        Level.Error,
         1,
         "flake8",
         "A random & fake linting issue",
@@ -101,7 +102,7 @@ def test_full_file(mock_revision, mock_hgmo):
         "mock-analyzer-fullfile",
         "path/to/afile.py",
         0,
-        "error",
+        Level.Error,
         -1,
         "fullfile",
         "Some issue found on a file",

--- a/bot/tests/test_lint.py
+++ b/bot/tests/test_lint.py
@@ -6,6 +6,7 @@
 import json
 import os
 
+from code_review_bot import Level
 from code_review_bot.tasks.lint import MozLintIssue
 from code_review_bot.tasks.lint import MozLintTask
 from conftest import FIXTURES_DIR
@@ -21,7 +22,7 @@ def test_flake8_checks(mock_config, mock_revision, mock_hgmo):
         "mock-lint-flake8",
         "test.py",
         1,
-        "error",
+        Level.Error,
         1,
         "flake8",
         "Dummy test",
@@ -36,7 +37,7 @@ def test_flake8_checks(mock_config, mock_revision, mock_hgmo):
         "mock-lint-flake8",
         "test.py",
         1,
-        "error",
+        Level.Error,
         1,
         "flake8",
         "Remove bad quotes or whatever.",
@@ -71,7 +72,7 @@ def test_as_text(mock_config, mock_revision, mock_hgmo):
         "mock-lint-flake8",
         "test.py",
         1,
-        "error",
+        Level.Error,
         1,
         "flake8",
         "dummy test withUppercaseChars",

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -9,6 +9,8 @@ import urllib
 
 import responses
 
+from code_review_bot import Level
+
 VALID_CLANG_TIDY_MESSAGE = """
 Code analysis found 1 defect in the diff 42:
  - 1 defect found by clang-tidy
@@ -248,7 +250,7 @@ def test_phabricator_mozlint(mock_config, mock_phabricator, mock_try_task):
         lineno=42,
         column=1,
         message="A bad bad error",
-        level="error",
+        level=Level.Error,
         revision=revision,
         linter="flake8",
         check="EXXX",
@@ -474,7 +476,7 @@ def test_phabricator_analyzers(mock_config, mock_phabricator, mock_try_task):
                 "mock-lint-flake8",
                 "test.cpp",
                 1,
-                "error",
+                Level.Error,
                 42,
                 "flake8",
                 "Python error",


### PR DESCRIPTION
Refs #364

Next steps would be : 
1. Always publish errors on Phabricator - supporting issues outside of the patch as lint errors
2. display errors & warnings clearly on the frontend