### PR TITLE
Remove useless Harbormaster publication mode

### DIFF
--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -33,7 +33,6 @@ class PhabricatorReporter(Reporter):
         ), "analyzers_skipped must be a list"
 
         self.publish_build_errors = configuration.get("publish_build_errors", False)
-        logger.info("Will publish using", build_errors=self.publish_build_errors)
 
     def setup_api(self, api):
         assert isinstance(api, PhabricatorAPI)


### PR DESCRIPTION
Prep work for #364 
I'm removing the unused Harbormaster publication mode in order to have only one publication workflow on Phabricator:
- one comment to summarize issues
- inline comments for in patch issues
- unit results for build errors
- lint results for extra errors (outside of patch) :new: 