### PR TITLE
Common Phabricator unit & lint results

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -11,6 +11,8 @@ import os
 
 import requests
 import structlog
+from libmozdata.phabricator import UnitResult
+from libmozdata.phabricator import UnitResultState
 from taskcluster.helper import TaskclusterConfig
 
 from code_review_bot.stats import InfluxDb
@@ -238,9 +240,19 @@ class Issue(abc.ABC):
 
     def as_phabricator_unitresult(self):
         """
-        Build a Phabricator UnitResult to publish through Harbormaster API
+        Build a Phabricator UnitResult for build errors
         """
-        raise NotImplementedError
+        assert (
+            self.is_build_error()
+        ), "Only build errors may be published as unit results"
+
+        return UnitResult(
+            namespace="code-review",
+            name="general",
+            result=UnitResultState.Fail,
+            details=f"Code review bot found a **build error**: \n{self.message}",
+            format="remarkup",
+        )
 
     def is_build_error(self):
         """

--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -11,6 +11,7 @@ import os
 
 import requests
 import structlog
+from libmozdata.phabricator import LintResult
 from libmozdata.phabricator import UnitResult
 from libmozdata.phabricator import UnitResultState
 from taskcluster.helper import TaskclusterConfig
@@ -230,13 +231,20 @@ class Issue(abc.ABC):
             "hash": issue_hash,
         }
 
-    @abc.abstractmethod
     def as_phabricator_lint(self):
         """
         Build the Phabricator LintResult instance
-        Used by the HarborMaster reporter
         """
-        raise NotImplementedError
+        return LintResult(
+            name=self.analyzer,
+            description=self.message,
+            code=self.check,
+            severity=self.level.value,
+            path=self.path,
+            # Report full file issues on line 1
+            line=self.line if self.line is not None else 1,
+            char=self.column,
+        )
 
     def as_phabricator_unitresult(self):
         """

--- a/bot/code_review_bot/tasks/clang_format.py
+++ b/bot/code_review_bot/tasks/clang_format.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import structlog
-from libmozdata.phabricator import LintResult
 
 from code_review_bot import Issue
 from code_review_bot import Level
@@ -48,7 +47,9 @@ class ClangFormatIssue(Issue):
         Build the text body published on reporters
         According to diff mode
         """
-        return "Warning: Incorrect coding style [clang-format]"
+        if self.patch:
+            return "Replace with :\n\n```{}```".format(self.patch)
+        return "Incorrect coding style [clang-format]"
 
     def as_markdown(self):
         """
@@ -56,23 +57,6 @@ class ClangFormatIssue(Issue):
         """
         return ISSUE_MARKDOWN.format(
             path=self.path, line=self.line, nb_lines=self.nb_lines
-        )
-
-    def as_phabricator_lint(self):
-        """
-        Outputs a Phabricator lint result
-        """
-        description = None
-        if self.patch:
-            description = "Replace with :\n\n```{}```".format(self.patch)
-        return LintResult(
-            name="C/C++ style issue",
-            description=description,
-            code="clang-format",
-            severity="warning",
-            path=self.path,
-            line=self.line,
-            char=self.column,
         )
 
 

--- a/bot/code_review_bot/tasks/clang_tidy.py
+++ b/bot/code_review_bot/tasks/clang_tidy.py
@@ -7,7 +7,6 @@
 import re
 
 import structlog
-from libmozdata.phabricator import LintResult
 
 from code_review_bot import Issue
 from code_review_bot import Level
@@ -146,28 +145,6 @@ class ClangTidyIssue(Issue):
                     for n in self.notes
                 ]
             ),
-        )
-
-    def as_phabricator_lint(self):
-        """
-        Outputs a Phabricator lint result
-        """
-        description = self.message
-
-        # Append to description the reliability index if any
-        if self.reliability != Reliability.Unknown:
-            description += "\nChecker reliability is {0}, meaning that the false positive ratio is {1}.".format(
-                self.reliability.value, self.reliability.invert
-            )
-
-        return LintResult(
-            name="Clang-Tidy - {}".format(self.check),
-            description=description,
-            code="clang-tidy.{}".format(self.check),
-            severity="warning",
-            path=self.path,
-            line=self.line,
-            char=self.column,
         )
 
 

--- a/bot/code_review_bot/tasks/coverage.py
+++ b/bot/code_review_bot/tasks/coverage.py
@@ -64,19 +64,6 @@ class CoverageIssue(Issue):
             publishable=self.is_publishable() and "yes" or "no",
         )
 
-    def as_phabricator_lint(self):
-        """
-        Outputs a Phabricator lint result
-        """
-        return {
-            "name": self.message,
-            "code": "coverage",
-            "severity": "warning",
-            "path": self.path,
-            # Report full file issues on line 1
-            "line": self.line if self.line is not None else 1,
-        }
-
 
 class ZeroCoverageTask(AnalysisTask):
     """

--- a/bot/code_review_bot/tasks/coverity.py
+++ b/bot/code_review_bot/tasks/coverity.py
@@ -4,7 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import structlog
-from libmozdata.phabricator import LintResult
 
 from code_review_bot import Issue
 from code_review_bot import Level
@@ -137,25 +136,6 @@ class CoverityIssue(Issue):
 
         return ERROR_MARKDOWN.format(
             message=self.message, location="{}:{}".format(self.path, self.line)
-        )
-
-    def as_phabricator_lint(self):
-        """
-        Outputs a Phabricator lint result
-        """
-        # If there is the reliability index use it
-        message = (
-            f"Checker reliability is {self.reliability.value}, meaning that the false positive ratio is {self.reliability.invert}.\n{self.message}"
-            if self.reliability != Reliability.Unknown
-            else self.message
-        )
-
-        return LintResult(
-            name=message,
-            code="coverity.{}".format(self.check),
-            severity="error",
-            path=self.path,
-            line=self.line,
         )
 
     def is_build_error(self):

--- a/bot/code_review_bot/tasks/coverity.py
+++ b/bot/code_review_bot/tasks/coverity.py
@@ -5,8 +5,6 @@
 
 import structlog
 from libmozdata.phabricator import LintResult
-from libmozdata.phabricator import UnitResult
-from libmozdata.phabricator import UnitResultState
 
 from code_review_bot import Issue
 from code_review_bot import Level
@@ -158,23 +156,6 @@ class CoverityIssue(Issue):
             severity="error",
             path=self.path,
             line=self.line,
-        )
-
-    def as_phabricator_unitresult(self):
-        """
-        Output an UnitResult if this is a build error
-        """
-        if not self.build_error:
-            raise Exception("Current issue is not a build error: {}".format(self))
-
-        message = f"Code review bot found a **build error**: \n{self.message}"
-
-        return UnitResult(
-            namespace="code-review",
-            name="general",
-            result=UnitResultState.Fail,
-            details=message,
-            format="remarkup",
         )
 
     def is_build_error(self):

--- a/bot/code_review_bot/tasks/default.py
+++ b/bot/code_review_bot/tasks/default.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import structlog
-from libmozdata.phabricator import LintResult
 
 from code_review_bot import Issue
 from code_review_bot import Level
@@ -49,20 +48,6 @@ class DefaultIssue(Issue):
             line=self.line,
             message=self.message,
             publishable=self.is_publishable() and "yes" or "no",
-        )
-
-    def as_phabricator_lint(self):
-        """
-        Outputs a Phabricator lint result
-        """
-        return LintResult(
-            name=f"Issue {self.analyzer}",
-            description=self.message,
-            code=self.check,
-            severity=self.level,
-            path=self.path,
-            line=self.line,
-            char=self.column,
         )
 
 

--- a/bot/code_review_bot/tasks/infer.py
+++ b/bot/code_review_bot/tasks/infer.py
@@ -4,7 +4,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import structlog
-from libmozdata.phabricator import LintResult
 
 from code_review_bot import Issue
 from code_review_bot import Level
@@ -21,15 +20,6 @@ ISSUE_MARKDOWN = """
 - **Infer check**: {check}
 - **Publishable **: {publishable}
 """
-
-INFER_SETUP_CMD = [
-    "gecko-env",
-    "./mach",
-    "artifact",
-    "toolchain",
-    "--from-build",
-    "linux64-infer",
-]
 
 
 class InferIssue(Issue):
@@ -75,20 +65,6 @@ class InferIssue(Issue):
             location="{}:{}:{}".format(self.path, self.line, self.column),
             in_patch="yes" if self.revision.contains(self) else "no",
             publishable="yes" if self.is_publishable() else "no",
-        )
-
-    def as_phabricator_lint(self):
-        """
-        Outputs a Phabricator lint result
-        """
-        return LintResult(
-            name=self.message,
-            code="infer.{}".format(self.check),
-            severity=self.level,
-            path=self.path,
-            line=self.line,
-            char=self.column,
-            description="Infer detected an issue on this line",
         )
 
 

--- a/bot/code_review_bot/tasks/lint.py
+++ b/bot/code_review_bot/tasks/lint.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import structlog
-from libmozdata.phabricator import LintResult
 
 from code_review_bot import Issue
 from code_review_bot import Level
@@ -97,25 +96,6 @@ class MozLintIssue(Issue):
             message=self.message,
             publishable=self.is_publishable() and "yes" or "no",
             disabled_check=self.is_disabled_check() and "yes" or "no",
-        )
-
-    def as_phabricator_lint(self):
-        """
-        Outputs a Phabricator lint result
-        """
-        code = self.linter
-        name = "MozLint {}".format(self.linter.capitalize())
-        if self.check:
-            code += ".{}".format(self.check)
-            name += " - {}".format(self.check)
-        return LintResult(
-            name=name,
-            description=self.message,
-            code=code,
-            severity=self.level.value,
-            path=self.path,
-            line=self.line,
-            char=self.column,
         )
 
 

--- a/bot/tests/test_clang.py
+++ b/bot/tests/test_clang.py
@@ -150,10 +150,10 @@ def test_as_markdown(mock_revision):
     )
     assert issue.as_phabricator_lint() == {
         "char": 51,
-        "code": "clang-tidy.dummy-check",
+        "code": "dummy-check",
         "line": 42,
-        "name": "Clang-Tidy - dummy-check",
-        "description": "dummy message\nChecker reliability is high, meaning that the false positive ratio is low.",
+        "name": "clang-tidy",
+        "description": "dummy message",
         "path": "test.cpp",
         "severity": "warning",
     }

--- a/bot/tests/test_coverage.py
+++ b/bot/tests/test_coverage.py
@@ -52,9 +52,10 @@ def test_coverage(mock_config, mock_revision, mock_coverage_artifact, mock_hgmo)
         "hash": "c64ebc6d4a3297b192364db4b022e5e2",
     }
     assert issue.as_phabricator_lint() == {
-        "code": "coverage",
+        "code": "no-coverage",
         "line": 1,
-        "name": "This file is uncovered",
+        "name": "coverage",
+        "description": "This file is uncovered",
         "path": "my/path/file1.cpp",
         "severity": "warning",
     }
@@ -99,9 +100,10 @@ This file is uncovered
         "hash": "0cbf1c1105c3b06ea9e8067a50a7e2f6",
     }
     assert issue.as_phabricator_lint() == {
-        "code": "coverage",
+        "code": "no-coverage",
         "line": 1,
-        "name": "This file is uncovered",
+        "name": "coverage",
+        "description": "This file is uncovered",
         "path": "test/dummy/thirdparty.c",
         "severity": "warning",
     }
@@ -143,9 +145,10 @@ This file is uncovered
         "hash": "9319c5bebc687cb439302ca049a9bff7",
     }
     assert issue.as_phabricator_lint() == {
-        "code": "coverage",
+        "code": "no-coverage",
         "line": 1,
-        "name": "This file is uncovered",
+        "name": "coverage",
+        "description": "This file is uncovered",
         "path": "my/path/header.h",
         "severity": "warning",
     }

--- a/bot/tests/test_coverity.py
+++ b/bot/tests/test_coverity.py
@@ -85,8 +85,8 @@ The path that leads to this defect is:
     assert issue.validates()
     assert not issue.is_publishable()
 
-    checker_desc = """Checker reliability is medium, meaning that the false positive ratio is medium.
-Dereferencing a pointer that might be "nullptr" "env" when calling "lookupImport".
+    reliability = "Checker reliability is medium, meaning that the false positive ratio is medium."
+    checker_desc = """Dereferencing a pointer that might be "nullptr" "env" when calling "lookupImport".
 The path that leads to this defect is:
 
 - //js/src/jit/BaselineCompiler.cpp:3697//:
@@ -99,14 +99,15 @@ The path that leads to this defect is:
 -- `dereference: Dereferencing a pointer that might be "nullptr" "env" when calling "lookupImport".`.
 """
     assert issue.as_phabricator_lint() == {
-        "code": "coverity.NULL_RETURNS",
+        "code": "NULL_RETURNS",
         "line": 3703,
-        "name": checker_desc,
+        "name": "mock-coverity",
         "path": "js/src/jit/BaselineCompiler.cpp",
-        "severity": "error",
+        "severity": "warning",
+        "description": checker_desc,
     }
 
-    assert issue.as_text() == checker_desc
+    assert issue.as_text() == reliability + "\n" + checker_desc
     assert issue.as_dict() == {
         "analyzer": "mock-coverity",
         "in_patch": False,

--- a/bot/tests/test_lint.py
+++ b/bot/tests/test_lint.py
@@ -85,9 +85,9 @@ def test_as_text(mock_config, mock_revision, mock_hgmo):
 
     assert issue.as_phabricator_lint() == {
         "char": 1,
-        "code": "flake8.dummy rule",
+        "code": "dummy rule",
         "line": 1,
-        "name": "MozLint Flake8 - dummy rule",
+        "name": "mock-lint-flake8",
         "description": "dummy test withUppercaseChars",
         "path": "test.py",
         "severity": "error",


### PR DESCRIPTION
Prep work for #364 

Every issue needed to implement `as_phabricator_lint` & `as_phabricator_unitresult`. But we have re-organized the Issue inner data earlier, allowing us to have a unique implementation for these methods.

The unit results are only used by Coverity (for build errors), but every Issue will be able to post a lint result now (for an error outside the patch).

The good news is that the payload do not change a lot (even if they were not used until now) as you can see in the unit tests.