### PR TITLE
Publish errors

### DIFF
--- a/backend/code_review_backend/issues/api.py
+++ b/backend/code_review_backend/issues/api.py
@@ -14,6 +14,7 @@ from rest_framework import routers
 from rest_framework import viewsets
 
 from code_review_backend.issues.compare import detect_new_for_revision
+from code_review_backend.issues.models import LEVEL_ERROR
 from code_review_backend.issues.models import Diff
 from code_review_backend.issues.models import Issue
 from code_review_backend.issues.models import Repository
@@ -86,7 +87,10 @@ class DiffViewSet(viewsets.ReadOnlyModelViewSet):
             .annotate(nb_errors=Count("issues", filter=Q(issues__level="error")))
             .annotate(nb_warnings=Count("issues", filter=Q(issues__level="warning")))
             .annotate(
-                nb_issues_publishable=Count("issues", filter=Q(issues__in_patch=True))
+                nb_issues_publishable=Count(
+                    "issues",
+                    filter=Q(issues__in_patch=True) | Q(issues__level=LEVEL_ERROR),
+                )
             )
             .order_by("-id")
         )
@@ -152,7 +156,9 @@ class IssueCheckStats(generics.ListAPIView):
     queryset = (
         Issue.objects.values("analyzer", "check", "diff__revision__repository__slug")
         .annotate(total=Count("id"))
-        .annotate(publishable=Count("id", filter=Q(in_patch=True)))
+        .annotate(
+            publishable=Count("id", filter=Q(in_patch=True) | Q(level=LEVEL_ERROR))
+        )
         .order_by("-total")
     )
 

--- a/backend/code_review_backend/issues/models.py
+++ b/backend/code_review_backend/issues/models.py
@@ -117,4 +117,4 @@ class Issue(models.Model):
     @property
     def publishable(self):
         """Is that issue publishable on Phabricator to developers"""
-        return self.in_patch is True
+        return self.in_patch is True or self.level == LEVEL_ERROR

--- a/backend/code_review_backend/issues/tests/test_issue.py
+++ b/backend/code_review_backend/issues/tests/test_issue.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from django.test import TestCase
+
+from code_review_backend.issues.models import LEVEL_ERROR
+from code_review_backend.issues.models import LEVEL_WARNING
+from code_review_backend.issues.models import Issue
+
+
+class IssueTestCase(TestCase):
+    def test_publishable(self):
+
+        # A warning is not publishable
+        issue = Issue.objects.create(path="some/file", line=12, level=LEVEL_WARNING)
+        self.assertFalse(issue.publishable)
+
+        # An error is publishable
+        issue = Issue.objects.create(path="some/file", line=12, level=LEVEL_ERROR)
+        self.assertTrue(issue.publishable)
+
+        # A warning in a patch is publishable
+        issue = Issue.objects.create(
+            path="some/file", line=12, level=LEVEL_WARNING, in_patch=True
+        )
+        self.assertTrue(issue.publishable)

--- a/backend/code_review_backend/issues/tests/test_issue.py
+++ b/backend/code_review_backend/issues/tests/test_issue.py
@@ -26,3 +26,9 @@ class IssueTestCase(TestCase):
             path="some/file", line=12, level=LEVEL_WARNING, in_patch=True
         )
         self.assertTrue(issue.publishable)
+
+        # An error in a patch is publishable
+        issue = Issue.objects.create(
+            path="some/file", line=12, level=LEVEL_ERROR, in_patch=True
+        )
+        self.assertTrue(issue.publishable)

--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -118,6 +118,10 @@ class Issue(abc.ABC):
         if not self.validates():
             return False
 
+        # An error is always published
+        if self.level == Level.Error:
+            return True
+
         # Then check if the backend marks this issue as publishable
         if self.on_backend is not None:
             return self.on_backend["publishable"]

--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -3,11 +3,14 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from typing import List
+
 import structlog
 from libmozdata.phabricator import BuildState
 from libmozdata.phabricator import PhabricatorAPI
 
 from code_review_bot import Issue
+from code_review_bot import Level
 from code_review_bot import stats
 from code_review_bot.report.base import Reporter
 from code_review_bot.revisions import Revision
@@ -16,6 +19,8 @@ from code_review_bot.tasks.coverage import CoverageIssue
 BUG_REPORT_URL = "https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__"  # noqa
 
 logger = structlog.get_logger(__name__)
+
+Issues = List[Issue]
 
 
 class PhabricatorReporter(Reporter):
@@ -41,7 +46,10 @@ class PhabricatorReporter(Reporter):
 
     def publish(self, issues, revision, task_failures):
         """
-        Publish inline comments for each issues
+        Publish issues on Phabricator:
+        * in patch issues use inline comments
+        * outside errors are displayed as lint results
+        * build errors are displayed as unit test results
         """
         if not isinstance(revision, Revision):
             logger.info(
@@ -70,25 +78,39 @@ class PhabricatorReporter(Reporter):
             # Always publish comment summarizing issues
             self.publish_comment(revision, issues_only, patches, task_failures)
 
-            # Also publish build issues
-            if self.publish_build_errors:
-                self.publish_harbormaster_build_errors(revision, build_errors)
+            # Publish all errors outside of the patch as lint issues
+            lint_issues = [
+                issue
+                for issue in issues_only
+                if not revision.contains(issue) and issue.level == Level.Error
+            ]
+
+            # Also publish build errors as Phabricator unit result
+            unit_issues = build_errors if self.publish_build_errors else []
+
+            # Publish on Harbormaster all at once
+            self.publish_harbormaster(revision, lint_issues, unit_issues)
         else:
             logger.info("No issues to publish on phabricator")
 
         return issues, patches
 
-    def publish_harbormaster_build_errors(self, revision, issues):
+    def publish_harbormaster(
+        self, revision, lint_issues: Issues = [], unit_issues: Issues = []
+    ):
         """
-        Publish build errors through Phabricator UnitResult
+        Publish issues through HarborMaster
+        either as lint results or unit tests results
         """
-        if not issues:
-            logger.info("No build errors encountered")
+        if not lint_issues and not unit_issues:
+            logger.info("No issues to publish as Phabricator lint or unit results")
             return
+
         self.api.update_build_target(
             revision.build_target_phid,
-            BuildState.Fail,
-            unit=[issue.as_phabricator_unitresult() for issue in issues],
+            state=BuildState.Work,
+            lint=[issue.as_phabricator_lint() for issue in lint_issues],
+            unit=[issue.as_phabricator_unitresult() for issue in unit_issues],
         )
 
     def publish_comment(self, revision, issues, patches, task_failures):
@@ -112,6 +134,7 @@ class PhabricatorReporter(Reporter):
         # First publish inlines as drafts
         # * skipping coverage issues as they get a dedicated comment
         # * skipping issues reported in a patch
+        # * skipping issues not in the current patch
         inlines = list(
             filter(
                 None,
@@ -120,6 +143,7 @@ class PhabricatorReporter(Reporter):
                     for issue in issues
                     if issue in non_coverage_issues
                     and issue.analyzer not in patches_analyzers
+                    and revision.contains(issue)
                 ],
             )
         )

--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -129,6 +129,11 @@ class PhabricatorReporter(Reporter):
         non_coverage_issues = [
             issue for issue in issues if not isinstance(issue, CoverageIssue)
         ]
+        errors = [
+            issue
+            for issue in issues
+            if issue.level == Level.Error and not revision.contains(issue)
+        ]
         patches_analyzers = set(p.analyzer for p in patches)
 
         # First publish inlines as drafts
@@ -147,7 +152,13 @@ class PhabricatorReporter(Reporter):
                 ],
             )
         )
-        if not inlines and not patches and not coverage_issues and not task_failures:
+        if (
+            not inlines
+            and not patches
+            and not coverage_issues
+            and not task_failures
+            and not errors
+        ):
             logger.info("No new comments found, skipping Phabricator publication")
             return
         logger.info("Added inline comments", ids=[i["id"] for i in inlines])

--- a/bot/tests/test_default.py
+++ b/bot/tests/test_default.py
@@ -93,7 +93,7 @@ def test_parser(mock_workflow, mock_revision, mock_hgmo, mock_backend):
 - **Level**: error
 - **Check**: XYZ
 - **Line**: 42
-- **Publishable**: no
+- **Publishable**: yes
 
 ```
 A random issue happened here
@@ -113,6 +113,6 @@ A random issue happened here
         "message": "A random issue happened here",
         "nb_lines": 1,
         "path": "test.cpp",
-        "publishable": False,
+        "publishable": True,
         "validates": True,
     }

--- a/bot/tests/test_hash.py
+++ b/bot/tests/test_hash.py
@@ -129,6 +129,6 @@ def test_full_file(mock_revision, mock_hgmo):
         "message": "Some issue found on a file",
         "nb_lines": 1,
         "path": "path/to/afile.py",
-        "publishable": False,
+        "publishable": True,
         "validates": True,
     }

--- a/bot/tests/test_lint.py
+++ b/bot/tests/test_lint.py
@@ -103,7 +103,7 @@ def test_as_text(mock_config, mock_revision, mock_hgmo):
         "message": "dummy test withUppercaseChars",
         "nb_lines": 1,
         "path": "test.py",
-        "publishable": False,
+        "publishable": True,
         "validates": True,
         "hash": "34c27d119c21ea5a2cd3f6ac230d8c4e",
     }

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -140,12 +140,12 @@ def test_baseline(mock_config, mock_revision, mock_workflow, mock_backend, mock_
             ("code-review.analysis.files", None, 2),
             ("code-review.analysis.lines", None, 2),
             ("code-review.issues", "source-test-mozlint-flake8", 1),
-            ("code-review.issues.publishable", "source-test-mozlint-flake8", 0),
+            ("code-review.issues.publishable", "source-test-mozlint-flake8", 1),
             ("code-review.issues.paths", "source-test-mozlint-flake8", 1),
             ("code-review.issues", "source-test-mozlint-zero-cov", 1),
             ("code-review.issues.publishable", "source-test-mozlint-zero-cov", 1),
             ("code-review.issues.paths", "source-test-mozlint-zero-cov", 1),
-            ("code-review.analysis.issues.publishable", None, 1),
+            ("code-review.analysis.issues.publishable", None, 2),
             ("code-review.runtime.reports", None, "runtime"),
         ]
     )
@@ -365,9 +365,9 @@ def test_mozlint_task(mock_config, mock_revision, mock_workflow, mock_backend):
             ("code-review.analysis.files", None, 2),
             ("code-review.analysis.lines", None, 2),
             ("code-review.issues", "source-test-mozlint-dummy", 1),
-            ("code-review.issues.publishable", "source-test-mozlint-dummy", 0),
+            ("code-review.issues.publishable", "source-test-mozlint-dummy", 1),
             ("code-review.issues.paths", "source-test-mozlint-dummy", 1),
-            ("code-review.analysis.issues.publishable", None, 0),
+            ("code-review.analysis.issues.publishable", None, 1),
             ("code-review.runtime.reports", None, "runtime"),
         ]
     )

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -564,7 +564,7 @@ def test_phabricator_unitresult(mock_phabricator, mock_try_task):
     from code_review_bot.report.phabricator import PhabricatorReporter
     from code_review_bot.revisions import Revision
 
-    def _check_unitresult(request):
+    def _check_message(request):
         # Check the Phabricator main comment is well formed
         payload = urllib.parse.parse_qs(request.body)
         assert payload["output"] == ["json"]
@@ -582,7 +582,7 @@ def test_phabricator_unitresult(mock_phabricator, mock_try_task):
                     "result": "fail",
                 }
             ],
-            "type": "fail",
+            "type": "work",
             "__conduit__": {"token": "deadbeef"},
         }
 
@@ -598,7 +598,7 @@ def test_phabricator_unitresult(mock_phabricator, mock_try_task):
     responses.add_callback(
         responses.POST,
         "http://phabricator.test/api/harbormaster.sendmessage",
-        callback=_check_unitresult,
+        callback=_check_message,
     )
 
     with mock_phabricator as api:


### PR DESCRIPTION
Requires #417 
Refs #364 

This PR will report all errors, even if they are outside a patch (as Phabricator lint results).

:information_source: I'm adding some unit tests to cover that new publication.