### PR TITLE
Add switch to publish errors & always publish errors as Lint results when enabled

### DIFF
--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -84,12 +84,10 @@ class PhabricatorReporter(Reporter):
             # Always publish comment summarizing issues
             self.publish_comment(revision, issues_only, patches, task_failures)
 
-            # Publish all errors outside of the patch as lint issues
+            # Publish all errors as lint issues
             if self.publish_errors:
                 lint_issues = [
-                    issue
-                    for issue in issues_only
-                    if not revision.contains(issue) and issue.level == Level.Error
+                    issue for issue in issues_only if issue.level == Level.Error
                 ]
             else:
                 lint_issues = []
@@ -141,9 +139,7 @@ class PhabricatorReporter(Reporter):
         errors = [
             issue
             for issue in issues
-            if issue.level == Level.Error
-            and not revision.contains(issue)
-            and self.publish_errors
+            if issue.level == Level.Error and self.publish_errors
         ]
         patches_analyzers = set(p.analyzer for p in patches)
 
@@ -151,6 +147,7 @@ class PhabricatorReporter(Reporter):
         # * skipping coverage issues as they get a dedicated comment
         # * skipping issues reported in a patch
         # * skipping issues not in the current patch
+        # * skipping errors as they are reported as lint
         inlines = list(
             filter(
                 None,
@@ -160,6 +157,7 @@ class PhabricatorReporter(Reporter):
                     if issue in non_coverage_issues
                     and issue.analyzer not in patches_analyzers
                     and revision.contains(issue)
+                    and issue.level == Level.Warning
                 ],
             )
         )

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -274,7 +274,8 @@ def test_phabricator_mozlint(mock_config, mock_phabricator, mock_try_task):
     # Check the callback has been used
     assert len(responses.calls) > 0
     call = responses.calls[-1]
-    print(list(responses.calls))
+    for c in responses.calls:
+        print(c.request.url)
     assert call.request.url == "http://phabricator.test/api/differential.createcomment"
     assert call.response.headers.get("unittest") == "flake8"
 

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -212,13 +212,43 @@ def test_phabricator_clang_format(mock_config, mock_phabricator, mock_try_task):
     assert call.response.headers.get("unittest") == "clang-format"
 
 
-def test_phabricator_mozlint(mock_config, mock_phabricator, mock_try_task):
+@pytest.mark.parametrize(
+    "reporter_config, errors_reported",
+    [({"publish_errors": True}, True), ({"publish_errors": False}, False), ({}, False)],
+)
+def test_phabricator_mozlint(
+    reporter_config, errors_reported, mock_config, mock_phabricator, mock_try_task
+):
     """
     Test Phabricator reporter publication on a mock mozlint issue
     """
     from code_review_bot.report.phabricator import PhabricatorReporter
     from code_review_bot.revisions import Revision
     from code_review_bot.tasks.lint import MozLintIssue
+
+    def _check_inline(request):
+        payload = urllib.parse.parse_qs(request.body)
+        assert payload["output"] == ["json"]
+        assert len(payload["params"]) == 1
+        details = json.loads(payload["params"][0])
+
+        assert details == {
+            "__conduit__": {"token": "deadbeef"},
+            "content": "Error: A bad bad error [flake8: EXXX]",
+            "diffID": 42,
+            "filePath": "python/test.py",
+            "isNewFile": 1,
+            "lineLength": 0,
+            "lineNumber": 42,
+        }
+
+        # Outputs dummy empty response
+        resp = {"error_code": None, "result": {"id": "PHID-XXXX-YYYYY"}}
+        return (
+            201,
+            {"Content-Type": "application/json", "unittest": "flake8-inline"},
+            json.dumps(resp),
+        )
 
     def _check_comment(request):
         # Check the Phabricator main comment is well formed
@@ -234,14 +264,57 @@ def test_phabricator_mozlint(mock_config, mock_phabricator, mock_try_task):
         resp = {"error_code": None, "result": None}
         return (
             201,
-            {"Content-Type": "application/json", "unittest": "flake8"},
+            {"Content-Type": "application/json", "unittest": "flake8-comment"},
+            json.dumps(resp),
+        )
+
+    def _check_message(request):
+        payload = urllib.parse.parse_qs(request.body)
+        assert payload["output"] == ["json"]
+        assert len(payload["params"]) == 1
+        details = json.loads(payload["params"][0])
+        assert details == {
+            "buildTargetPHID": "PHID-HMBT-test",
+            "lint": [
+                {
+                    "char": 1,
+                    "code": "EXXX",
+                    "description": "A bad bad error",
+                    "line": 42,
+                    "name": "source-test-mozlint-py-flake8",
+                    "path": "python/test.py",
+                    "severity": "error",
+                }
+            ],
+            "unit": [],
+            "type": "work",
+            "__conduit__": {"token": "deadbeef"},
+        }
+
+        # Outputs dummy empty response
+        resp = {"error_code": None, "result": None}
+        return (
+            201,
+            {"Content-Type": "application/json", "unittest": "flake8-error"},
             json.dumps(resp),
         )
 
     responses.add_callback(
         responses.POST,
+        "http://phabricator.test/api/differential.createinline",
+        callback=_check_inline,
+    )
+
+    responses.add_callback(
+        responses.POST,
         "http://phabricator.test/api/differential.createcomment",
         callback=_check_comment,
+    )
+
+    responses.add_callback(
+        responses.POST,
+        "http://phabricator.test/api/harbormaster.sendmessage",
+        callback=_check_message,
     )
 
     with mock_phabricator as api:
@@ -252,7 +325,7 @@ def test_phabricator_mozlint(mock_config, mock_phabricator, mock_try_task):
             "dom/test.cpp": [42],
         }
         revision.files = revision.lines.keys()
-        reporter = PhabricatorReporter({"analyzers": ["clang-format"]}, api=api)
+        reporter = PhabricatorReporter(reporter_config, api=api)
 
     issue = MozLintIssue(
         analyzer="source-test-mozlint-py-flake8",
@@ -271,13 +344,26 @@ def test_phabricator_mozlint(mock_config, mock_phabricator, mock_try_task):
     assert len(issues) == 1
     assert len(patches) == 0
 
-    # Check the callback has been used
+    # Check the callbacks have been used to publish either:
+    # - an inline comment + summary comment when publish_errors is False
+    # - a lint result + summary comment when publish_errors is True
     assert len(responses.calls) > 0
-    call = responses.calls[-1]
-    for c in responses.calls:
-        print(c.request.url)
-    assert call.request.url == "http://phabricator.test/api/differential.createcomment"
-    assert call.response.headers.get("unittest") == "flake8"
+    if errors_reported:
+        urls = [
+            "http://phabricator.test/api/differential.createcomment",
+            "http://phabricator.test/api/harbormaster.sendmessage",
+        ]
+        markers = ["flake8-comment", "flake8-error"]
+
+    else:
+        urls = [
+            "http://phabricator.test/api/differential.createinline",
+            "http://phabricator.test/api/differential.createcomment",
+        ]
+        markers = ["flake8-inline", "flake8-comment"]
+
+    assert [r.request.url for r in responses.calls[-2:]] == urls
+    assert [r.response.headers.get("unittest") for r in responses.calls[-2:]] == markers
 
 
 def test_phabricator_coverage(mock_config, mock_phabricator, mock_try_task):


### PR DESCRIPTION
Fixes #25 

This PR support both modes of operations:
- Maintains the current mode where errors & warnings in patch are published as inline (when `publish_errors: False` in config & by default)
- Publishes all errors (regardless of their in_patch state) as lint results  (when `publish_errors: Trie` in config)