### PR TITLE
events: Await any pending tasks at shutdown

### DIFF
--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -468,6 +468,9 @@ class Events(object):
             # Keep the web server process running
             asyncio.get_event_loop().run_forever()
 
+        # Make sure any pending task is run.
+        run_tasks(asyncio.Task.all_tasks())
+
         # Stop the webserver when other async processes are stopped
         if self.webserver:
             self.webserver.stop()


### PR DESCRIPTION
I don't know if it's actually useful, but I guess it can't hurt.