### PR TITLE
events: Pass runnable-jobs from the decision task when triggering a bugbug test selection task

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 159
 exclude = .git,__pycache__,data,tools
-ignore = E203,W503
+ignore = E203,E501,W503

--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -16,7 +16,7 @@ from code_review_bot.report.base import Reporter
 from code_review_bot.revisions import Revision
 from code_review_bot.tasks.coverage import CoverageIssue
 
-BUG_REPORT_URL = "https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__"  # noqa
+BUG_REPORT_URL = "https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__"
 
 logger = structlog.get_logger(__name__)
 

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -20,7 +20,7 @@ You can run this analysis locally with:
  - `./mach static-analysis check another_test.cpp` (C/C++)
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
-"""  # noqa
+"""
 
 VALID_CLANG_FORMAT_MESSAGE = """
 Code analysis found 1 defect in the diff 42:
@@ -32,7 +32,7 @@ You can run this analysis locally with:
 For your convenience, [here is a patch]({results}/clang-format-PHID-DIFF-test.diff) that fixes all the clang-format defects (use it in your repository with `hg import` or `git apply -p0`).
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
-"""  # noqa
+"""
 
 
 VALID_FLAKE8_MESSAGE = """
@@ -43,7 +43,7 @@ You can run this analysis locally with:
  - `./mach lint --warnings path/to/file` (JS/Python/etc)
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
-"""  # noqa
+"""
 
 
 VALID_COVERAGE_MESSAGE = """
@@ -56,21 +56,21 @@ Should they have tests, or are they dead code ?
  - You can file a bug blocking [Bug 1415819](https://bugzilla.mozilla.org/show_bug.cgi?id=1415819) for untested files that should be **removed**.
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
-"""  # noqa
+"""
 
 VALID_DEFAULT_MESSAGE = """
 Code analysis found 1 defect in the diff 42:
  - 1 defect found by full-file-analyzer
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
-"""  # noqa
+"""
 
 VALID_TASK_FAILURES_MESSAGE = """
 The analysis task [mock-infer](https://firefox-ci-tc.services.mozilla.com/tasks/erroneousTaskId) failed, but we could not detect any issue.
 Please check this task manually.
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
-"""  # noqa
+"""
 
 
 VALID_MOZLINT_MESSAGE = """
@@ -81,7 +81,7 @@ You can run this analysis locally with:
  - `./mach lint --warnings path/to/file` (JS/Python/etc)
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
-"""  # noqa
+"""
 
 
 def test_phabricator_clang_tidy(mock_phabricator, mock_try_task):

--- a/events/code_review_events/bugbug_utils.py
+++ b/events/code_review_events/bugbug_utils.py
@@ -119,15 +119,15 @@ class BugbugUtils:
             },
         )
 
+        # Start test selection
+        await self.start_test_selection(build, extras["revision"])
+
     async def process_build(self, build):
         assert build is not None, "Invalid payload"
         assert isinstance(build, PhabricatorBuild)
 
         # Start risk analysis
         await self.start_risk_analysis(build)
-
-        # Start test selection
-        await self.start_test_selection(build)
 
     def should_run_risk_analysis(self, build):
         """
@@ -184,7 +184,7 @@ class BugbugUtils:
 
         return random.random() < self.test_selection_share
 
-    async def start_test_selection(self, build: PhabricatorBuild):
+    async def start_test_selection(self, build: PhabricatorBuild, revision: str):
         """
         Run test selection by triggering a Taskcluster hook
         """
@@ -199,6 +199,11 @@ class BugbugUtils:
                 {
                     "PHABRICATOR_DEPLOYMENT": self.phabricator_deployment,
                     "DIFF_ID": build.diff_id,
+                    "RUNNABLE_JOBS": self.index_service.buildUrl(
+                        "findArtifactFromTask",
+                        f"gecko.v2.try.revision.{revision}.firefox.decision",
+                        "public/runnable-jobs.json",
+                    ),
                 },
             )
             task_id = task["status"]["taskId"]


### PR DESCRIPTION
This way bugbug can skip jobs which are not runnable.
Note: this will make test selection start a little later, as we start it after pushing to try rather than when we get the notification from Phabricator, but this should be a limited delay.