### PR TITLE
Use dind build only for bot

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -43,7 +43,7 @@ tasks:
         then: 'https://api.code-review.testing.moz.tools'
         else: 'https://api.code-review.moz.tools'
 
-    taskboot_image: "mozilla/taskboot:0.2.2"
+    taskboot_image: "mozilla/taskboot:0.2.1"
 
     pip_install: "pip install --disable-pip-version-check --no-cache-dir --quiet"
     python_version: "3.8"
@@ -170,8 +170,8 @@ tasks:
         - {$eval: as_slugid("check_lint")}
         - {$eval: as_slugid("bot_check_tests")}
       payload:
-        features:
-          dind: true
+        capabilities:
+          privileged: true
         maxRunTime: 3600
         image: "${taskboot_image}"
         env:
@@ -182,8 +182,6 @@ tasks:
           - build
           - --image
           - mozilla/code-review
-          - --build-tool
-          - dind
           - --tag
           - "${channel}"
           - --tag
@@ -196,6 +194,8 @@ tasks:
             expires: {$fromNow: '2 weeks'}
             path: /bot.tar
             type: file
+      scopes:
+        - docker-worker:capability:privileged
       metadata:
         name: Code Review Bot docker build
         description: Build docker image of code review bot
@@ -211,8 +211,8 @@ tasks:
         - {$eval: as_slugid("check_lint")}
         - {$eval: as_slugid("events_check_tests")}
       payload:
-        features:
-          dind: true
+        capabilities:
+          privileged: true
         maxRunTime: 3600
         image: "${taskboot_image}"
         env:
@@ -223,8 +223,6 @@ tasks:
           - build
           - --image
           - mozilla/code-review
-          - --build-tool
-          - dind
           - --tag
           - "${channel}"
           - --tag
@@ -237,6 +235,8 @@ tasks:
             expires: {$fromNow: '2 weeks'}
             path: /events.tar
             type: file
+      scopes:
+        - docker-worker:capability:privileged
       metadata:
         name: Code Review Events docker build
         description: Build docker image of code review events
@@ -252,8 +252,8 @@ tasks:
         - {$eval: as_slugid("check_lint")}
         - {$eval: as_slugid("backend_check_tests")}
       payload:
-        features:
-          dind: true
+        capabilities:
+          privileged: true
         maxRunTime: 3600
         image: "${taskboot_image}"
         env:
@@ -264,8 +264,6 @@ tasks:
           - build
           - --image
           - mozilla/code-review
-          - --build-tool
-          - dind
           - --tag
           - "${channel}"
           - --tag
@@ -278,6 +276,8 @@ tasks:
             expires: {$fromNow: '2 weeks'}
             path: /backend.tar
             type: file
+      scopes:
+        - docker-worker:capability:privileged
       metadata:
         name: Code Review Backend docker build
         description: Build docker image of code review backend
@@ -315,8 +315,8 @@ tasks:
         - {$eval: as_slugid("check_lint")}
         - {$eval: as_slugid("integration_check_tests")}
       payload:
-        features:
-          dind: true
+        capabilities:
+          privileged: true
         maxRunTime: 3600
         image: "${taskboot_image}"
         env:
@@ -325,8 +325,6 @@ tasks:
         command:
           - taskboot
           - build
-          - --build-tool
-          - dind
           - --image
           - mozilla/code-review
           - --tag
@@ -341,6 +339,8 @@ tasks:
             expires: {$fromNow: '2 weeks'}
             path: /integration.tar
             type: file
+      scopes:
+        - docker-worker:capability:privileged
       metadata:
         name: Code Review Integration docker build
         description: Build docker image of code review integration tests

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -237,8 +237,6 @@ tasks:
             expires: {$fromNow: '2 weeks'}
             path: /bot.tar
             type: file
-      scopes:
-        - docker-worker:capability:privileged
       metadata:
         name: Code Review Bot docker in docker build
         description: Build docker image of code review bot, using a remote docker daemon

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -197,8 +197,51 @@ tasks:
       scopes:
         - docker-worker:capability:privileged
       metadata:
-        name: Code Review Bot docker build
-        description: Build docker image of code review bot
+        name: Code Review Bot docker img build
+        description: Build docker image of code review bot, using img on a privileged daemon
+        owner: bastien@mozilla.com
+        source: https://github.com/mozilla/code-review
+
+    - taskId: {$eval: as_slugid("bot_build_dind")}
+      created: {$fromNow: ''}
+      deadline: {$fromNow: '1 hour'}
+      provisionerId: proj-relman
+      workerType: ci
+      dependencies:
+        - {$eval: as_slugid("check_lint")}
+        - {$eval: as_slugid("bot_check_tests")}
+      payload:
+        features:
+          dind: true
+        maxRunTime: 3600
+        image: "${taskboot_image}"
+        env:
+          GIT_REPOSITORY: ${repository}
+          GIT_REVISION: ${head_rev}
+        command:
+          - taskboot
+          - build
+          - --build-tool
+          - dind
+          - --image
+          - mozilla/code-review
+          - --tag
+          - "${channel}"
+          - --tag
+          - "${head_rev}"
+          - --write
+          - /bot.tar
+          - bot/docker/Dockerfile
+        artifacts:
+          public/code-review-bot.tar:
+            expires: {$fromNow: '2 weeks'}
+            path: /bot.tar
+            type: file
+      scopes:
+        - docker-worker:capability:privileged
+      metadata:
+        name: Code Review Bot docker in docker build
+        description: Build docker image of code review bot, using a remote docker daemon
         owner: bastien@mozilla.com
         source: https://github.com/mozilla/code-review
 

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -43,7 +43,7 @@ tasks:
         then: 'https://api.code-review.testing.moz.tools'
         else: 'https://api.code-review.moz.tools'
 
-    taskboot_image: "mozilla/taskboot:0.2.1"
+    taskboot_image: "mozilla/taskboot:0.2.2"
 
     pip_install: "pip install --disable-pip-version-check --no-cache-dir --quiet"
     python_version: "3.8"


### PR DESCRIPTION
As skopeo cannot upload the old image format produced by Taskcluster dind, to update testing or production, we need to stick to privileged workers using img.

I'm still building the bot docker image with dind (that's the only one needed with dind on firefox-ci).

Also [Bug 1594102](https://bugzilla.mozilla.org/show_bug.cgi?id=1594102) is a bit stuck, so the workflow may change later on