### PR TITLE
Support TEST-UNEXPECTED-FAIL from logs

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -254,15 +254,19 @@ class Issue(abc.ABC):
         """
         Build a Phabricator UnitResult for build errors
         """
-        assert (
-            self.is_build_error()
-        ), "Only build errors may be published as unit results"
+        if self.is_build_error():
+            details = f"Code review bot found a **build error**: \n{self.message}"
+            name = "general"
+        else:
+            details = self.message
+            name = self.check or "test"
 
         return UnitResult(
             namespace="code-review",
-            name="general",
+            name=name,
+            engine=self.analyzer,
             result=UnitResultState.Fail,
-            details=f"Code review bot found a **build error**: \n{self.message}",
+            details=details,
             format="remarkup",
         )
 

--- a/bot/code_review_bot/tasks/tests.py
+++ b/bot/code_review_bot/tasks/tests.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+import re
+
+import structlog
+
+from code_review_bot import Issue
+from code_review_bot import Level
+from code_review_bot.tasks.base import AnalysisTask
+
+logger = structlog.get_logger(__name__)
+
+FAILURE_REGEX = re.compile(
+    r"^\[([\w:\.\- ]+)\] TEST-UNEXPECTED-FAIL (.*)$", re.MULTILINE
+)
+
+ISSUE_MARKDOWN = """
+## test failure {analyzer}
+
+- **Level**: {level}
+- **Publishable**: {publishable}
+
+```
+{message}
+```
+"""
+
+
+class TestsIssue(Issue):
+    def __init__(self, analyzer, revision, message):
+        self.analyzer = analyzer
+        self.revision = revision
+        self.message = message
+        self.level = Level.Error
+        self.path = ""
+
+    def validates(self):
+        """
+        Tests issues are valid as long as they match the format
+        """
+        return True
+
+    def as_text(self):
+        """
+        Build the text content for reporters
+        """
+        return "test {}: {}".format(self.level.name, self.message)
+
+    def as_markdown(self):
+        """
+        Build the Markdown content for debug email
+        """
+        return ISSUE_MARKDOWN.format(
+            analyzer=self.analyzer,
+            level=self.level.value,
+            message=self.message,
+            publishable=self.is_publishable() and "yes" or "no",
+        )
+
+
+class TestsTask(AnalysisTask):
+    """
+    Parse TEST-UNEXCPECTED-FAIL failures from logs
+    """
+
+    artifacts = ["public/logs/live.log"]
+
+    def parse_issues(self, artifacts, revision):
+        """
+        Parse issues from the task's live log
+        """
+        assert isinstance(artifacts, dict)
+
+        return [
+            TestsIssue(analyzer=self.name, revision=revision, message=match[1])
+            for artifact in artifacts.values()
+            for match in FAILURE_REGEX.findall(artifact.decode("utf-8"))
+        ]

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -24,6 +24,7 @@ from code_review_bot.tasks.coverity import CoverityTask
 from code_review_bot.tasks.default import DefaultTask
 from code_review_bot.tasks.infer import InferTask
 from code_review_bot.tasks.lint import MozLintTask
+from code_review_bot.tasks.tests import TestsTask
 from code_review_tools.taskcluster import TASKCLUSTER_DATE_FORMAT
 
 logger = structlog.get_logger(__name__)
@@ -394,6 +395,8 @@ class Workflow(object):
             return CoverityTask(task_id, task_status)
         elif name == "source-test-infer-infer":
             return InferTask(task_id, task_status)
+        elif name in ("source-test-node-debugger-tests",):
+            return TestsTask(task_id, task_status)
         elif name.startswith("source-test-"):
             logger.error(f"Unsupported {name} task: will need a local implementation")
         else:

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -674,6 +674,7 @@ The path that leads to this defect is:
         namespace="code-review",
         name="general",
         result=UnitResultState.Fail,
+        engine="source-test-coverity-coverity",
         details=f"Code review bot found a **build error**: \n{issue.message}",
         format="remarkup",
     )

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -679,6 +679,7 @@ def test_phabricator_unitresult(mock_phabricator, mock_try_task):
                     "details": 'Code review bot found a **build error**: \nDereferencing a pointer that might be "nullptr" "env" when calling "lookupImport".',
                     "format": "remarkup",
                     "name": "general",
+                    "engine": "mock-coverity",
                     "namespace": "code-review",
                     "result": "fail",
                 }


### PR DESCRIPTION
Fixes #41 

I'm not sure this is the best way to tackle this as TEST-UNEXPECTED-FAIL usually lacks the file path & test name.