### PR TITLE
Use treeherder url for task failures

### DIFF
--- a/bot/code_review_bot/report/base.py
+++ b/bot/code_review_bot/report/base.py
@@ -8,6 +8,8 @@ import re
 import urllib.parse
 from typing import Pattern
 
+from code_review_tools import treeherder
+
 HELP_COMMANDS = {
     "source-test-clang-tidy": " - `./mach static-analysis check {files}` (C/C++)",
     "source-test-infer-infer": " - `./mach static-analysis check-java path/to/file.java` (Java)",
@@ -39,7 +41,7 @@ COMMENT_DIFF_DOWNLOAD = """
 For your convenience, [here is a patch]({url}) that fixes all the {analyzer} defects (use it in your repository with `hg import` or `git apply -p0`).
 """
 COMMENT_TASK_FAILURE = """
-The analysis task [{name}](https://firefox-ci-tc.services.mozilla.com/tasks/{task_id}) failed, but we could not detect any issue.
+The analysis task [{name}]({url}) failed, but we could not detect any issue.
 Please check this task manually.
 """
 
@@ -171,7 +173,10 @@ class Reporter(object):
             )
 
         for task in task_failures:
-            comment += COMMENT_TASK_FAILURE.format(name=task.name, task_id=task.id)
+            treeherder_url = treeherder.get_job_url(
+                task.id, task.run_id, revision=revision.mercurial_revision
+            )
+            comment += COMMENT_TASK_FAILURE.format(name=task.name, url=treeherder_url)
 
         assert comment != "", "Empty comment"
 

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -395,7 +395,7 @@ class Workflow(object):
         elif name == "source-test-infer-infer":
             return InferTask(task_id, task_status)
         elif name.startswith("source-test-"):
-            logger.error(f"Unsupported {name} task: will need a local implementation")
+            return DefaultTask(task_id, task_status)
         else:
             # Log cleanly for autoland, but send a warning on try
             log = (

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -605,3 +605,13 @@ def mock_backend(mock_backend_secret):
     )
 
     return revisions, diffs, issues
+
+
+@pytest.fixture
+def mock_treeherder():
+    responses.add(
+        responses.GET,
+        "https://treeherder.mozilla.org/api/jobdetail/",
+        body=json.dumps({"results": [{"job_id": 1234}]}),
+        content_type="application/json",
+    )

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -66,7 +66,7 @@ If you see a problem in this automated review, [please report it here](https://b
 """
 
 VALID_TASK_FAILURES_MESSAGE = """
-The analysis task [mock-infer](https://firefox-ci-tc.services.mozilla.com/tasks/erroneousTaskId) failed, but we could not detect any issue.
+The analysis task [mock-infer](https://treeherder.mozilla.org/#/jobs?revision=aabbccddee&selectedJob=1234) failed, but we could not detect any issue.
 Please check this task manually.
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
@@ -864,7 +864,7 @@ def test_full_file(mock_config, mock_phabricator, mock_try_task):
     assert call.response.headers.get("unittest") == "full-file-inline"
 
 
-def test_task_failures(mock_phabricator, mock_try_task):
+def test_task_failures(mock_phabricator, mock_try_task, mock_treeherder):
     """
     Test Phabricator reporter publication with some task failures
     """
@@ -901,10 +901,14 @@ def test_task_failures(mock_phabricator, mock_try_task):
 
     with mock_phabricator as api:
         revision = Revision.from_try(mock_try_task, api)
+        revision.mercurial_revision = "aabbccddee"
         reporter = PhabricatorReporter({"analyzers": ["clang-tidy"]}, api=api)
 
-    status = {"task": {"metadata": {"name": "mock-infer"}}, "status": {}}
-    task = ClangTidyTask("erroneousTaskId", status)
+    status = {
+        "task": {"metadata": {"name": "mock-infer"}},
+        "status": {"runs": [{"runId": 0}]},
+    }
+    task = ClangTidyTask("ab3NrysvSZyEwsOHL2MZfw", status)
     issues, patches = reporter.publish([], revision, [task])
     assert len(issues) == 0
     assert len(patches) == 0

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -13,6 +13,7 @@ from code_review_bot.revisions import Revision
 from code_review_bot.tasks.clang_format import ClangFormatTask
 from code_review_bot.tasks.clang_tidy import ClangTidyTask
 from code_review_bot.tasks.coverity import CoverityTask
+from code_review_bot.tasks.default import DefaultTask
 from code_review_bot.tasks.infer import InferTask
 from code_review_bot.tasks.lint import MozLintTask
 
@@ -90,7 +91,7 @@ def test_taskcluster_index(mock_config, mock_workflow, mock_try_task):
         ("source-test-clang-format", ClangFormatTask),
         ("source-test-coverity-coverity", CoverityTask),
         ("source-test-infer-infer", InferTask),
-        ("source-test-unsupported", None),
+        ("source-test-unsupported", DefaultTask),
         ("totally-unsupported", None),
     ],
 )

--- a/events/requirements.txt
+++ b/events/requirements.txt
@@ -4,4 +4,3 @@ jsonschema==3.2.0
 libmozdata==0.1.64
 libmozevent==1.1.3
 pyyaml==5.3
-treeherder-client==5.0.0

--- a/tools/code_review_tools/treeherder.py
+++ b/tools/code_review_tools/treeherder.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from urllib.parse import urlencode
+
+import slugid
+from thclient import TreeherderClient
+
+
+def get_job_url(task_id, run_id, **params):
+    """Build a Treeherder job url for a given Taskcluster task"""
+    treeherder_client = TreeherderClient()
+    uuid = slugid.decode(task_id)
+
+    # Fetch specific job id from treeherder
+    job_details = treeherder_client.get_job_details(job_guid=f"{uuid}/{run_id}")
+    if len(job_details) > 0:
+        params["selectedJob"] = job_details[0]["job_id"]
+
+    return f"https://treeherder.mozilla.org/#/jobs?{urlencode(params)}"

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,4 +5,5 @@ multidict==4.5.2
 raven==6.10.0
 structlog==20.1.0
 taskcluster==24.2.0
+treeherder-client==5.0.0
 yarl==1.3.0


### PR DESCRIPTION
Hopefully almost fixes #41 ...

Several things are happening here:
1. i'm sharing the treeherder job url between events & bot - it's setup in code_review_tools
2. events is updated to use that method
3. the bot uses the treeherder url for a task failure (instead of the Taskcluster frontend view) - displaying potential issues
4. A `DefaultTask` is used for all `source-test-*` tasks, meaning that any failing task from `source-test` will use the task failure mechanism.

A followup would be to report such failures through use unit results instead of a comment.