### PR TITLE
Use task group id to find decision task

### DIFF
--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -391,20 +391,16 @@ class Revision(object):
         """
         self.improvement_patches = []
 
-    def setup_try(self, tasks):
+    def setup_try(self, task_group_id, tasks):
         """
         Find the mercurial revision from the Try decision task env
         """
-        # Find the decision task
-        def is_decision_task(task):
-            image = task["task"]["payload"].get("image")
-            if image is not None and isinstance(image, str):
-                return image.startswith("taskcluster/decision") or image.startswith(
-                    "djmitche/nss-decision"
-                )
-
-        decision_task = next(filter(is_decision_task, tasks.values()), None)
+        # The decision task should have the same id as the task group
+        decision_task = tasks.get(task_group_id)
         assert decision_task is not None, "Missing decision task"
+        logger.info(
+            "Found decision task", name=decision_task["task"]["metadata"]["name"]
+        )
 
         # Use mercurial infos for local revision
         decision_env = decision_task["task"]["payload"]["env"]

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -266,12 +266,10 @@ class Workflow(object):
         assert "tasks" in tasks
         tasks = {task["status"]["taskId"]: task for task in tasks["tasks"]}
         assert len(tasks) > 0
-        logger.info(
-            "Loaded Taskcluster group", id=settings.try_group_id, tasks=len(tasks)
-        )
+        logger.info("Loaded Taskcluster group", id=group_id, tasks=len(tasks))
 
         # Update the local revision with tasks
-        revision.setup_try(tasks)
+        revision.setup_try(group_id, tasks)
 
         # Store the revision in the backend
         # It needs to be after setup_try to have a repository value

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -386,7 +386,7 @@ def mock_backend_secret(mock_taskcluster_config):
 
 
 @pytest.fixture
-def mock_workflow(mock_phabricator, mock_taskcluster_config):
+def mock_workflow(mock_config, mock_phabricator, mock_taskcluster_config):
     """
     Mock the workflow along with Taskcluster mocks
     No phabricator output here
@@ -414,6 +414,9 @@ def mock_workflow(mock_phabricator, mock_taskcluster_config):
             """
             Add mock tasks in queue & index mock services
             """
+            # The task group id is used to find the decision task
+            # as it should be the first task in the group
+            mock_config.try_group_id = "decision"
             self.index_service.configure(tasks)
             self.queue_service.configure(tasks)
 

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -415,7 +415,7 @@ def mock_workflow(mock_config, mock_phabricator, mock_taskcluster_config):
             Add mock tasks in queue & index mock services
             """
             # The task group id is used to find the decision task
-            # as it should be the first task in the group
+            # as it's the task with the same ID as the group
             mock_config.try_group_id = "decision"
             self.index_service.configure(tasks)
             self.queue_service.configure(tasks)

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -250,16 +250,16 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
     """
 
     mock_workflow.setup_mock_tasks({"decision": {}, "remoteTryTask": {}})
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Missing decision task"
+    assert str(e.value) == "Unsupported decision task"
 
     mock_workflow.setup_mock_tasks(
         {"decision": {"image": "anotherImage"}, "remoteTryTask": {}}
     )
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Missing decision task"
+    assert str(e.value) == "Unsupported decision task"
 
     mock_workflow.setup_mock_tasks(
         {
@@ -269,9 +269,9 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
             "remoteTryTask": {},
         }
     )
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Missing decision task"
+    assert str(e.value) == "Unsupported decision task"
 
     mock_workflow.setup_mock_tasks(
         {"decision": {"image": "taskcluster/decision:XXX"}, "remoteTryTask": {}}

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -249,6 +249,11 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
     Test a remote workflow with different decision task setup
     """
 
+    mock_workflow.setup_mock_tasks({"notDecision": {}, "remoteTryTask": {}})
+    with pytest.raises(Exception) as e:
+        mock_workflow.run(mock_revision)
+    assert str(e.value) == "Missing decision task"
+
     mock_workflow.setup_mock_tasks({"decision": {}, "remoteTryTask": {}})
     with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)

--- a/bot/tests/test_reporter_debug.py
+++ b/bot/tests/test_reporter_debug.py
@@ -16,10 +16,12 @@ def test_publication(tmpdir, mock_issues, mock_revision):
 
     # Load description from Taskcluster tasks
     mock_revision.setup_try(
+        "decision",
         {
             # Base information are retrieved from the decision task
             "decision": {
                 "task": {
+                    "metadata": {"name": "Mock decision task"},
                     "payload": {
                         "image": "taskcluster/decision",
                         "env": {
@@ -27,10 +29,10 @@ def test_publication(tmpdir, mock_issues, mock_revision):
                             "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
                             "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-central",
                         },
-                    }
+                    },
                 }
             }
-        }
+        },
     )
 
     report_dir = str(tmpdir.mkdir("public").realpath())


### PR DESCRIPTION
Fixes #480

In the end, i used the heuristic `decision task id == try group id`, as it's possible to create tasks from the decision tasks without adding the decision task as a dependency, thus making it impossible to trace it back