### PR TITLE
Use repositories config from secret to find mercurial infos in decision task

### DIFF
--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -55,7 +55,13 @@ def main():
     taskcluster.load_secrets(
         args.taskcluster_secret,
         prefixes=["common", "code-review-bot", "bot"],
-        required=("APP_CHANNEL", "REPORTERS", "PHABRICATOR", "ALLOWED_PATHS"),
+        required=(
+            "APP_CHANNEL",
+            "REPORTERS",
+            "PHABRICATOR",
+            "ALLOWED_PATHS",
+            "repositories",
+        ),
         existing={
             "APP_CHANNEL": "development",
             "REPORTERS": [],
@@ -78,7 +84,9 @@ def main():
 
     # Setup settings before stats
     settings.setup(
-        taskcluster.secrets["APP_CHANNEL"], taskcluster.secrets["ALLOWED_PATHS"]
+        taskcluster.secrets["APP_CHANNEL"],
+        taskcluster.secrets["ALLOWED_PATHS"],
+        taskcluster.secrets["repositories"],
     )
     # Setup statistics
     influx_conf = taskcluster.secrets.get("influxdb")

--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -27,7 +27,7 @@ TaskCluster = collections.namedtuple(
     "TaskCluster", "results_dir, task_id, run_id, local"
 )
 RepositoryConf = collections.namedtuple(
-    "RepositoryConf", "url, decision_env_revision, decision_env_repository"
+    "RepositoryConf", "name, url, decision_env_revision, decision_env_repository"
 )
 
 

--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -16,7 +16,6 @@ import tempfile
 import structlog
 
 REPO_MOZILLA_CENTRAL = "https://hg.mozilla.org/mozilla-central"
-REPO_NSS = "https://hg.mozilla.org/projects/nss"
 REPO_AUTOLAND = "https://hg.mozilla.org/integration/autoland"
 REGEX_PHABRICATOR_COMMIT = re.compile(
     r"^Differential Revision: (https://[\w\-\.]+/D(\d+))$", re.MULTILINE
@@ -26,6 +25,9 @@ logger = structlog.get_logger(__name__)
 
 TaskCluster = collections.namedtuple(
     "TaskCluster", "results_dir, task_id, run_id, local"
+)
+RepositoryConf = collections.namedtuple(
+    "RepositoryConf", "url, decision_env_revision, decision_env_repository"
 )
 
 
@@ -44,11 +46,12 @@ class Settings(object):
         self.try_group_id = None
         self.autoland_group_id = None
         self.hgmo_cache = tempfile.mkdtemp(suffix="hgmo")
+        self.repositories = []
 
         # Always cleanup at the end of the execution
         atexit.register(self.cleanup)
 
-    def setup(self, app_channel, allowed_paths):
+    def setup(self, app_channel, allowed_paths, repositories):
         # Detect source from env
         if "TRY_TASK_ID" in os.environ and "TRY_TASK_GROUP_ID" in os.environ:
             self.try_task_id = os.environ["TRY_TASK_ID"]
@@ -76,6 +79,22 @@ class Settings(object):
         assert isinstance(allowed_paths, list)
         assert all(map(lambda p: isinstance(p, str), allowed_paths))
         self.allowed_paths = allowed_paths
+
+        # Build available repositories from secret
+        def build_conf(nb, repo):
+            assert isinstance(
+                repo, dict
+            ), "Repository configuration #{nb+1} is not a dict"
+            data = []
+            for key in RepositoryConf._fields:
+                assert (
+                    key in repo
+                ), f"Missing key {key} in repository configuration #{nb+1}"
+                data.append(repo[key])
+            return RepositoryConf._make(data)
+
+        self.repositories = [build_conf(i, repo) for i, repo in enumerate(repositories)]
+        assert self.repositories, "No repositories available"
 
     def __getattr__(self, key):
         if key not in self.config:

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -220,6 +220,13 @@ def mock_phabricator(mock_config):
         content_type="application/json",
     )
 
+    responses.add(
+        responses.POST,
+        "http://phabricator.test/api/diffusion.repository.search",
+        body=_response("repository_search"),
+        content_type="application/json",
+    )
+
     yield PhabricatorAPI(url="http://phabricator.test/api/", api_key="deadbeef")
 
 

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -28,7 +28,23 @@ MockArtifactResponse = namedtuple("MockArtifactResponse", "content")
 
 
 @pytest.fixture(scope="function")
-def mock_config():
+def mock_repositories():
+    return [
+        {
+            "url": "https://hg.mozilla.org/mozilla-central",
+            "decision_env_revision": "GECKO_HEAD_REV",
+            "decision_env_repository": "GECKO_HEAD_REPOSITORY",
+            "checkout": "robust",
+            "try_url": "ssh://hg.mozilla.org/try",
+            "try_mode": "json",
+            "name": "mozilla-central",
+            "ssh_user": "reviewbot@mozilla.com",
+        }
+    ]
+
+
+@pytest.fixture(scope="function")
+def mock_config(mock_repositories):
     """
     Mock configuration for bot
     Using try source
@@ -38,7 +54,7 @@ def mock_config():
         del os.environ["TASK_ID"]
     os.environ["TRY_TASK_ID"] = "remoteTryTask"
     os.environ["TRY_TASK_GROUP_ID"] = "remoteTryGroup"
-    settings.setup("test", ["dom/*", "tests/*.py", "test/*.c"])
+    settings.setup("test", ["dom/*", "tests/*.py", "test/*.c"], mock_repositories)
     return settings
 
 

--- a/bot/tests/mocks/phabricator_repository_search.json
+++ b/bot/tests/mocks/phabricator_repository_search.json
@@ -1,0 +1,50 @@
+{
+  "result": {
+    "data": [
+      {
+        "id": 1,
+        "type": "REPO",
+        "phid": "PHID-REPO-mc",
+        "fields": {
+          "name": "mozilla-central",
+          "vcs": "hg",
+          "callsign": "MOZILLACENTRAL",
+          "shortName": "mozilla-central",
+          "status": "active",
+          "isImporting": false,
+          "almanacServicePHID": null,
+          "refRules": {
+            "fetchRules": [],
+            "trackRules": [],
+            "permanentRefRules": []
+          },
+          "defaultBranch": "default",
+          "description": {
+            "raw": ""
+          },
+          "spacePHID": null,
+          "dateCreated": 1502986064,
+          "dateModified": 1558793245,
+          "policy": {
+            "view": "public",
+            "edit": "admin",
+            "diffusion.push": "no-one"
+          }
+        },
+        "attachments": {}
+      }
+    ],
+    "maps": {},
+    "query": {
+      "queryKey": null
+    },
+    "cursor": {
+      "limit": 100,
+      "after": null,
+      "before": null,
+      "order": null
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/test_patch.py
+++ b/bot/tests/test_patch.py
@@ -9,7 +9,7 @@ from code_review_bot.config import settings
 from code_review_bot.revisions import ImprovementPatch
 
 
-def test_publication(monkeypatch, mock_taskcluster_config):
+def test_publication(monkeypatch, mock_taskcluster_config, mock_repositories):
     """
     Check a patch publication through Taskcluster services
     """
@@ -18,7 +18,7 @@ def test_publication(monkeypatch, mock_taskcluster_config):
     monkeypatch.setenv("TASK_ID", "fakeTaskId")
     monkeypatch.setenv("RUN_ID", "0")
     monkeypatch.setenv("TASKCLUSTER_PROXY_URL", "http://proxy")
-    settings.setup("test", [])
+    settings.setup("test", [], mock_repositories)
 
     # Mock the storage response
     responses.add(

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -294,9 +294,9 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
             "remoteTryTask": {},
         }
     )
-    with pytest.raises(AssertionError) as e:
+    with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Missing try revision"
+    assert str(e.value) == "Unsupported decision task"
     assert mock_revision.mercurial_revision is None
 
     mock_workflow.setup_mock_tasks(

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -248,6 +248,7 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
     """
     Test a remote workflow with different decision task setup
     """
+    assert mock_revision.phabricator_repository["fields"]["name"] == "mozilla-central"
 
     mock_workflow.setup_mock_tasks({"notDecision": {}, "remoteTryTask": {}})
     with pytest.raises(Exception) as e:
@@ -255,16 +256,24 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
     assert str(e.value) == "Missing decision task"
 
     mock_workflow.setup_mock_tasks({"decision": {}, "remoteTryTask": {}})
-    with pytest.raises(Exception) as e:
+    with pytest.raises(AssertionError) as e:
+        mock_revision.phabricator_repository["fields"]["name"] = "unknown"
         mock_workflow.run(mock_revision)
     assert str(e.value) == "Unsupported decision task"
+
+    # Restore name
+    mock_revision.phabricator_repository["fields"]["name"] = "mozilla-central"
+    mock_workflow.setup_mock_tasks({"decision": {}, "remoteTryTask": {}})
+    with pytest.raises(Exception) as e:
+        mock_workflow.run(mock_revision)
+    assert str(e.value) == "Revision GECKO_HEAD_REV not found in decision task"
 
     mock_workflow.setup_mock_tasks(
         {"decision": {"image": "anotherImage"}, "remoteTryTask": {}}
     )
     with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Unsupported decision task"
+    assert str(e.value) == "Revision GECKO_HEAD_REV not found in decision task"
 
     mock_workflow.setup_mock_tasks(
         {
@@ -276,7 +285,7 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
     )
     with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Unsupported decision task"
+    assert str(e.value) == "Revision GECKO_HEAD_REV not found in decision task"
 
     mock_workflow.setup_mock_tasks(
         {"decision": {"image": "taskcluster/decision:XXX"}, "remoteTryTask": {}}
@@ -289,14 +298,14 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
         {
             "decision": {
                 "image": "taskcluster/decision:XXX",
-                "env": {"GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try"},
+                "env": {"GECKO_HEAD_REV": "someRevision"},
             },
             "remoteTryTask": {},
         }
     )
     with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Revision GECKO_HEAD_REV not found in decision task"
+    assert str(e.value) == "Repository GECKO_HEAD_REPOSITORY not found in decision task"
     assert mock_revision.mercurial_revision is None
 
     mock_workflow.setup_mock_tasks(
@@ -304,8 +313,8 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
             "decision": {
                 "image": "taskcluster/decision:XXX",
                 "env": {
-                    "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
                     "GECKO_HEAD_REV": "someRevision",
+                    "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
                 },
             },
             "remoteTryTask": {},

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -283,7 +283,7 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
     )
     with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Unsupported decision task"
+    assert str(e.value) == "Revision GECKO_HEAD_REV not found in decision task"
 
     mock_workflow.setup_mock_tasks(
         {
@@ -296,7 +296,7 @@ def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):
     )
     with pytest.raises(Exception) as e:
         mock_workflow.run(mock_revision)
-    assert str(e.value) == "Unsupported decision task"
+    assert str(e.value) == "Revision GECKO_HEAD_REV not found in decision task"
     assert mock_revision.mercurial_revision is None
 
     mock_workflow.setup_mock_tasks(

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -119,7 +119,7 @@ def test_build_task(task_name, result, mock_workflow):
         assert isinstance(task, result)
 
 
-def test_on_production(mock_config):
+def test_on_production(mock_config, mock_repositories):
     """
     Test the production environment detection
     """
@@ -132,7 +132,7 @@ def test_on_production(mock_config):
     os.environ["TASK_ID"] = "testingTask"
     os.environ["RUN_ID"] = "0"
     testing = Settings()
-    testing.setup("testing", [])
+    testing.setup("testing", [], mock_repositories)
     assert testing.app_channel == "testing"
     assert testing.taskcluster.local is False
     assert testing.on_production is False
@@ -141,7 +141,7 @@ def test_on_production(mock_config):
     os.environ["TASK_ID"] = "prodTask"
     os.environ["RUN_ID"] = "0"
     testing = Settings()
-    testing.setup("production", [])
+    testing.setup("production", [], mock_repositories)
     assert testing.app_channel == "production"
     assert testing.taskcluster.local is False
     assert testing.on_production is True


### PR DESCRIPTION
Fixes #479

When releasing, i'll simply need to move the existing `repositories` configuration in secret in **common**  section, and then add the relevant decision keys.