### PR TITLE
bot: The repo parameter of the Treeherder URL should be the name of the repository, not its URL

### DIFF
--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -27,7 +27,8 @@ TaskCluster = collections.namedtuple(
     "TaskCluster", "results_dir, task_id, run_id, local"
 )
 RepositoryConf = collections.namedtuple(
-    "RepositoryConf", "name, url, decision_env_revision, decision_env_repository"
+    "RepositoryConf",
+    "name, try_name, url, decision_env_revision, decision_env_repository",
 )
 
 

--- a/bot/code_review_bot/report/base.py
+++ b/bot/code_review_bot/report/base.py
@@ -183,7 +183,10 @@ class Reporter(object):
 
         for task in task_failures:
             treeherder_url = treeherder.get_job_url(
-                revision.repository, revision.mercurial_revision, task.id, task.run_id
+                revision.repository_try_name,
+                revision.mercurial_revision,
+                task.id,
+                task.run_id,
             )
             comment += COMMENT_TASK_FAILURE.format(name=task.name, url=treeherder_url)
 
@@ -193,7 +196,7 @@ class Reporter(object):
 
         if defects:
             treeherder_url = treeherder.get_job_url(
-                revision.repository, revision.mercurial_revision
+                revision.repository_try_name, revision.mercurial_revision
             )
             comment += FRONTEND_LINKS.format(
                 frontend_url=frontend_url, treeherder_url=treeherder_url

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -81,6 +81,7 @@ class Revision(object):
         build_target_phid=None,
         mercurial_revision=None,
         repository=None,
+        repository_try_name=None,
         target_repository=None,
         phabricator_repository=None,
         url=None,
@@ -100,6 +101,9 @@ class Revision(object):
 
         # a try repo where the revision is stored
         self.repository = repository
+
+        # the name of the try repo where the revision is stored
+        self.repository_try_name = repository_try_name
 
         # the target repo where the patch may land
         self.target_repository = target_repository
@@ -424,6 +428,7 @@ class Revision(object):
                 assert (
                     repository.decision_env_repository in decision_env
                 ), f"Repository {repository.decision_env_repository} not found in decision task"
+                self.repository_try_name = repository.try_name
                 self.mercurial_revision = decision_env[repository.decision_env_revision]
                 self.repository = decision_env[repository.decision_env_repository]
                 self.target_repository = repository.url

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -37,6 +37,7 @@ def mock_repositories():
             "checkout": "robust",
             "try_url": "ssh://hg.mozilla.org/try",
             "try_mode": "json",
+            "try_name": "try",
             "name": "mozilla-central",
             "ssh_user": "reviewbot@mozilla.com",
         }

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -132,7 +132,8 @@ def test_phabricator_clang_tidy(mock_phabricator, mock_try_task):
     with mock_phabricator as api:
         revision = Revision.from_try(mock_try_task, api)
         revision.mercurial_revision = "deadbeef1234"
-        revision.repository = "try"
+        revision.repository = "https://hg.mozilla.org/try"
+        revision.repository_try_name = "try"
         revision.lines = {
             # Add dummy lines diff
             "another_test.cpp": [41, 42, 43]
@@ -197,7 +198,8 @@ def test_phabricator_clang_format(mock_config, mock_phabricator, mock_try_task):
     with mock_phabricator as api:
         revision = Revision.from_try(mock_try_task, api)
         revision.mercurial_revision = "deadbeef1234"
-        revision.repository = "try"
+        revision.repository = "https://hg.mozilla.org/try"
+        revision.repository_try_name = "try"
         revision.lines = {
             # Add dummy lines diff
             "test.cpp": [41, 42, 43],
@@ -334,7 +336,8 @@ def test_phabricator_mozlint(
     with mock_phabricator as api:
         revision = Revision.from_try(mock_try_task, api)
         revision.mercurial_revision = "deadbeef1234"
-        revision.repository = "try"
+        revision.repository = "https://hg.mozilla.org/try"
+        revision.repository_try_name = "try"
         revision.lines = {
             # Add dummy lines diff
             "python/test.py": [41, 42, 43],
@@ -499,7 +502,8 @@ def test_phabricator_clang_tidy_and_coverage(
     with mock_phabricator as api:
         revision = Revision.from_try(mock_try_task, api)
         revision.mercurial_revision = "deadbeef1234"
-        revision.repository = "try"
+        revision.repository = "https://hg.mozilla.org/try"
+        revision.repository_try_name = "try"
         revision.lines = {
             # Add dummy lines diff
             "test.txt": [0],
@@ -560,7 +564,8 @@ def test_phabricator_analyzers(mock_config, mock_phabricator, mock_try_task):
         # Always use the same setup, only varies the analyzers
         revision = Revision.from_try(mock_try_task, api)
         revision.mercurial_revision = "deadbeef1234"
-        revision.repository = "try"
+        revision.repository = "https://hg.mozilla.org/try"
+        revision.repository_try_name = "try"
         revision.lines = {"test.cpp": [0, 41, 42, 43], "dom/test.cpp": [42]}
         reporter = PhabricatorReporter(
             {"analyzers_skipped": analyzers_skipped}, api=api
@@ -845,7 +850,8 @@ def test_full_file(mock_config, mock_phabricator, mock_try_task):
     with mock_phabricator as api:
         revision = Revision.from_try(mock_try_task, api)
         revision.mercurial_revision = "deadbeef1234"
-        revision.repository = "try"
+        revision.repository = "https://hg.mozilla.org/try"
+        revision.repository_try_name = "try"
         revision.lines = {
             # Add dummy lines diff
             "xx.cpp": [123, 124, 125]
@@ -924,7 +930,8 @@ def test_task_failures(mock_phabricator, mock_try_task, mock_treeherder):
     with mock_phabricator as api:
         revision = Revision.from_try(mock_try_task, api)
         revision.mercurial_revision = "aabbccddee"
-        revision.repository = "try"
+        revision.repository = "https://hg.mozilla.org/try"
+        revision.repository_try_name = "try"
         reporter = PhabricatorReporter({"analyzers": ["clang-tidy"]}, api=api)
 
     status = {
@@ -1053,7 +1060,8 @@ def test_extra_errors(
     with mock_phabricator as api:
         revision = Revision.from_try(mock_try_task, api)
         revision.mercurial_revision = "deadbeef1234"
-        revision.repository = "try"
+        revision.repository = "https://hg.mozilla.org/try"
+        revision.repository_try_name = "try"
         revision.lines = {"path/to/file.py": [1, 2, 3]}
         revision.files = ["path/to/file.py"]
         reporter = PhabricatorReporter(reporter_config, api=api)


### PR DESCRIPTION
Fixes #500.