### PR TITLE
Fix black setup on CI

### DIFF
--- a/bot/requirements-dev.txt
+++ b/bot/requirements-dev.txt
@@ -3,3 +3,6 @@ pytest==5.3.5
 pytest-responses==0.4.0
 pytest-structlog==0.2
 responses==0.10.11
+
+# Fix black setup issue with newer virtualenv
+virtualenv<=20.0.5


### PR DESCRIPTION
The latest virtualenv release breaks black setup in pre-commit.