### PR TITLE
Extend docker image lifetime to 6 months

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -145,7 +145,7 @@ tasks:
                 - bot/docker/Dockerfile
               artifacts:
                 public/code-review-bot.tar:
-                  expires: {$fromNow: '2 weeks'}
+                  expires: {$fromNow: '6 months'}
                   path: /bot.tar
                   type: file
             routes:


### PR DESCRIPTION
The docker image expired yesterday on the firefox-ci Taskcluster instance, so the bot did not publish any results for a day.
I've triggered a new production build, available for 2 weeks: https://firefox-ci-tc.services.mozilla.com/tasks/groups/MQugUdeIQjqasPWJq_M-AA