### PR TITLE
Use nicer analyzer names on Phabricator

### DIFF
--- a/bot/code_review_bot/report/base.py
+++ b/bot/code_review_bot/report/base.py
@@ -120,9 +120,9 @@ class Reporter(object):
         stats = self.calc_stats(issues)
 
         # Build parts depending on issues
-        defects, analyzers = [], []
+        defects, analyzers = set(), set()
         for stat in stats:
-            defects.append(
+            defects.add(
                 " - {nb} found by {analyzer}".format(
                     analyzer=stat["analyzer"],
                     nb=pluralize("defect", stat["publishable"]),
@@ -130,7 +130,11 @@ class Reporter(object):
             )
             _help = stat.get("help")
             if _help is not None:
-                analyzers.append(f" - {_help}")
+                analyzers.add(f" - {_help}")
+
+        # Order both sets
+        defects = sorted(defects)
+        analyzers = sorted(analyzers)
 
         # Build top comment
         nb = len(issues)

--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -55,12 +55,13 @@ class PhabricatorReporter(Reporter):
         issues = [
             issue
             for issue in issues
-            if issue.is_publishable() and issue.analyzer not in self.analyzers_skipped
+            if issue.is_publishable()
+            and issue.analyzer.name not in self.analyzers_skipped
         ]
         patches = [
             patch
             for patch in revision.improvement_patches
-            if patch.analyzer not in self.analyzers_skipped
+            if patch.analyzer.name not in self.analyzers_skipped
         ]
 
         if issues or task_failures:

--- a/bot/code_review_bot/tasks/base.py
+++ b/bot/code_review_bot/tasks/base.py
@@ -31,11 +31,27 @@ class AnalysisTask(object):
 
     @property
     def name(self):
+        """Short name used to identify the task"""
         return self.task["metadata"].get("name", "unknown")
+
+    @property
+    def display_name(self):
+        """
+        Longer name used to describe the task to humans
+        By default fallback to short name
+        """
+        return self.name
 
     @property
     def state(self):
         return self.status["state"]
+
+    def build_help_message(self, files):
+        """
+        An optional help message aimed at developers to reproduce the issues detection
+        A list of relative paths with issues is specified to build a precise message
+        By default it's empty (None)
+        """
 
     @classmethod
     def build_from_route(cls, index_service, queue_service):

--- a/bot/code_review_bot/tasks/clang_format.py
+++ b/bot/code_review_bot/tasks/clang_format.py
@@ -31,7 +31,7 @@ class ClangFormatIssue(Issue):
             line,
             nb_lines,
             check="invalid-styling",
-            message="Reformat C/C++",
+            message="The change does not follow the C/C++ coding style, please reformat",
             column=column,
             level=Level.Warning,
         )

--- a/bot/code_review_bot/tasks/clang_format.py
+++ b/bot/code_review_bot/tasks/clang_format.py
@@ -31,6 +31,7 @@ class ClangFormatIssue(Issue):
             line,
             nb_lines,
             check="invalid-styling",
+            message="Reformat C/C++",
             column=column,
             level=Level.Warning,
         )

--- a/bot/code_review_bot/tasks/clang_format.py
+++ b/bot/code_review_bot/tasks/clang_format.py
@@ -71,6 +71,14 @@ class ClangFormatTask(AnalysisTask):
         "public/code-review/clang-format.diff",
     ]
 
+    @property
+    def display_name(self):
+        return "clang-format"
+
+    def build_help_message(self, files):
+        files = " ".join(files)
+        return f"`./mach clang-format -s -p {files}` (C/C++)"
+
     def parse_issues(self, artifacts, revision):
         artifact = artifacts.get("public/code-review/clang-format.json")
         if artifact is None:
@@ -79,7 +87,7 @@ class ClangFormatTask(AnalysisTask):
 
         return [
             ClangFormatIssue(
-                analyzer=self.name,
+                analyzer=self,
                 path=path,
                 line=issue["line"],
                 nb_lines=issue["lines_modified"],

--- a/bot/code_review_bot/tasks/clang_tidy.py
+++ b/bot/code_review_bot/tasks/clang_tidy.py
@@ -155,10 +155,18 @@ class ClangTidyTask(AnalysisTask):
 
     artifacts = ["public/code-review/clang-tidy.json"]
 
+    @property
+    def display_name(self):
+        return "clang-tidy"
+
+    def build_help_message(self, files):
+        files = " ".join(files)
+        return f"`./mach static-analysis check {files}` (C/C++)"
+
     def parse_issues(self, artifacts, revision):
         return [
             ClangTidyIssue(
-                analyzer=self.name,
+                analyzer=self,
                 revision=revision,
                 path=path,
                 line=warning["line"],

--- a/bot/code_review_bot/tasks/coverage.py
+++ b/bot/code_review_bot/tasks/coverage.py
@@ -23,9 +23,9 @@ ISSUE_MARKDOWN = """
 
 
 class CoverageIssue(Issue):
-    def __init__(self, path, lineno, message, revision):
+    def __init__(self, analyzer, path, lineno, message, revision):
         super().__init__(
-            "coverage",
+            analyzer,
             revision,
             path,
             line=lineno and int(lineno) or None,
@@ -74,6 +74,10 @@ class ZeroCoverageTask(AnalysisTask):
     route = "project.relman.code-coverage.production.cron.latest"
     artifacts = ["public/zero_coverage_report.json"]
 
+    @property
+    def display_name(self):
+        return "code coverage analysis"
+
     def parse_issues(self, artifacts, revision):
         zero_coverage_files = {
             file_info["name"]
@@ -83,7 +87,7 @@ class ZeroCoverageTask(AnalysisTask):
         }
 
         return [
-            CoverageIssue(path, 0, "This file is uncovered", revision)
+            CoverageIssue(self, path, 0, "This file is uncovered", revision)
             for path in revision.files
             if path in zero_coverage_files
         ]

--- a/bot/code_review_bot/tasks/coverity.py
+++ b/bot/code_review_bot/tasks/coverity.py
@@ -159,7 +159,7 @@ class CoverityTask(AnalysisTask):
         assert isinstance(artifacts, dict)
         return [
             CoverityIssue(
-                analyzer=self.name, revision=revision, issue=warning, file_path=path
+                analyzer=self, revision=revision, issue=warning, file_path=path
             )
             for artifact in artifacts.values()
             for path, items in artifact["files"].items()

--- a/bot/code_review_bot/tasks/default.py
+++ b/bot/code_review_bot/tasks/default.py
@@ -41,7 +41,7 @@ class DefaultIssue(Issue):
         Build the Markdown content for debug email
         """
         return ISSUE_MARKDOWN.format(
-            analyzer=self.analyzer,
+            analyzer=self.analyzer.name,
             path=self.path,
             check=self.check,
             level=self.level.value,
@@ -77,7 +77,7 @@ class DefaultTask(AnalysisTask):
 
         return [
             DefaultIssue(
-                analyzer=issue.get("analyzer", self.name),
+                analyzer=self,
                 revision=revision,
                 path=issue["path"],
                 line=issue["line"],

--- a/bot/code_review_bot/tasks/infer.py
+++ b/bot/code_review_bot/tasks/infer.py
@@ -75,13 +75,17 @@ class InferTask(AnalysisTask):
 
     artifacts = ["public/code-review/infer.json"]
 
+    def build_help_message(self, files):
+        files = " ".join(files)
+        return f"`./mach static-analysis check-java {files} (Java)"
+
     def parse_issues(self, artifacts, revision):
         """
         Parse issues from a direct Infer JSON report
         """
         assert isinstance(artifacts, dict)
         return [
-            InferIssue(analyzer=self.name, revision=revision, entry=issue)
+            InferIssue(analyzer=self, revision=revision, entry=issue)
             for issues in artifacts.values()
             for issue in issues
         ]

--- a/bot/code_review_bot/tasks/lint.py
+++ b/bot/code_review_bot/tasks/lint.py
@@ -120,7 +120,7 @@ class MozLintTask(AnalysisTask):
     @property
     def display_name(self):
         if self.linter:
-            return f"{self.linter} (by MozLint)"
+            return f"{self.linter} (Mozlint)"
         if self.name.startswith("source-test-"):
             return self.name[12:]
         return self.name

--- a/bot/code_review_bot/tasks/lint.py
+++ b/bot/code_review_bot/tasks/lint.py
@@ -126,7 +126,7 @@ class MozLintTask(AnalysisTask):
         return self.name
 
     def build_help_message(self, files):
-        return "`./mach lint --warnings --outgoing` (JS/Python/etc)"
+        return "`./mach lint --warnings --outgoing`"
 
     def parse_issues(self, artifacts, revision):
         """

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -333,7 +333,7 @@ class Workflow(object):
 
                     task_patches = task.build_patches(artifacts)
                     for patch in task_patches:
-                        revision.add_improvement_patch(task.name, patch)
+                        revision.add_improvement_patch(task, patch)
 
                     # Report a problem when tasks in erroneous state are found
                     # but no issue or patch has been processed by the bot

--- a/bot/tests/test_clang.py
+++ b/bot/tests/test_clang.py
@@ -2,22 +2,17 @@
 import pytest
 
 from code_review_bot.tasks.clang_format import ClangFormatTask
+from code_review_bot.tasks.clang_tidy import ClangTidyIssue
+from code_review_bot.tasks.clang_tidy import ClangTidyTask
 
 
-def test_expanded_macros(mock_revision):
+def test_expanded_macros(mock_revision, mock_task):
     """
     Test expanded macros are detected by clang issue
     """
-    from code_review_bot.tasks.clang_tidy import ClangTidyIssue
-
+    analyzer = mock_task(ClangTidyTask, "clang-tidy")
     issue = ClangTidyIssue(
-        "clang-tidy",
-        mock_revision,
-        "test.cpp",
-        "42",
-        "51",
-        "dummy message",
-        "dummy-check",
+        analyzer, mock_revision, "test.cpp", "42", "51", "dummy message", "dummy-check"
     )
     assert issue.line == 42
     assert issue.column == 51
@@ -27,7 +22,7 @@ def test_expanded_macros(mock_revision):
     # Add a note starting with "expanded from macro..."
     issue.notes.append(
         ClangTidyIssue(
-            "clang-tidy",
+            analyzer,
             mock_revision,
             "test.cpp",
             "42",
@@ -41,7 +36,7 @@ def test_expanded_macros(mock_revision):
     # Add another note does not change it
     issue.notes.append(
         ClangTidyIssue(
-            "clang-tidy",
+            analyzer,
             mock_revision,
             "test.cpp",
             "42",
@@ -57,14 +52,13 @@ def test_expanded_macros(mock_revision):
     assert issue.is_expanded_macro() is False
 
 
-def test_as_text(mock_revision):
+def test_as_text(mock_revision, mock_task):
     """
     Test text export for ClangTidyIssue
     """
-    from code_review_bot.tasks.clang_tidy import ClangTidyIssue
 
     issue = ClangTidyIssue(
-        "clang-tidy",
+        mock_task(ClangTidyTask, "clang-tidy"),
         mock_revision,
         "test.cpp",
         "42",
@@ -79,15 +73,14 @@ def test_as_text(mock_revision):
     )
 
 
-def test_as_dict(mock_revision, mock_hgmo):
+def test_as_dict(mock_revision, mock_hgmo, mock_task):
     """
     Test text export for ClangTidyIssue
     """
     from code_review_bot import Reliability
-    from code_review_bot.tasks.clang_tidy import ClangTidyIssue
 
     issue = ClangTidyIssue(
-        "clang-tidy",
+        mock_task(ClangTidyTask, "clang-tidy"),
         mock_revision,
         "test.cpp",
         "42",
@@ -113,15 +106,14 @@ def test_as_dict(mock_revision, mock_hgmo):
     }
 
 
-def test_as_markdown(mock_revision):
+def test_as_markdown(mock_revision, mock_task):
     """
     Test markdown generation for ClangTidyIssue
     """
     from code_review_bot import Reliability
-    from code_review_bot.tasks.clang_tidy import ClangTidyIssue
 
     issue = ClangTidyIssue(
-        "clang-tidy",
+        mock_task(ClangTidyTask, "clang-tidy"),
         mock_revision,
         "test.cpp",
         "42",

--- a/bot/tests/test_coverage.py
+++ b/bot/tests/test_coverage.py
@@ -2,9 +2,10 @@
 from code_review_bot.tasks.coverage import ZeroCoverageTask
 
 
-def test_coverage(mock_config, mock_revision, mock_coverage_artifact, mock_hgmo):
-    task_status = {"task": {}, "status": {}}
-    cov = ZeroCoverageTask("covTaskId", task_status)
+def test_coverage(
+    mock_config, mock_revision, mock_coverage_artifact, mock_hgmo, mock_task
+):
+    cov = mock_task(ZeroCoverageTask, "coverage")
 
     mock_revision.files = [
         # Uncovered file
@@ -54,7 +55,7 @@ def test_coverage(mock_config, mock_revision, mock_coverage_artifact, mock_hgmo)
     assert issue.as_phabricator_lint() == {
         "code": "no-coverage",
         "line": 1,
-        "name": "coverage",
+        "name": "code coverage analysis",
         "description": "This file is uncovered",
         "path": "my/path/file1.cpp",
         "severity": "warning",
@@ -102,7 +103,7 @@ This file is uncovered
     assert issue.as_phabricator_lint() == {
         "code": "no-coverage",
         "line": 1,
-        "name": "coverage",
+        "name": "code coverage analysis",
         "description": "This file is uncovered",
         "path": "test/dummy/thirdparty.c",
         "severity": "warning",
@@ -147,7 +148,7 @@ This file is uncovered
     assert issue.as_phabricator_lint() == {
         "code": "no-coverage",
         "line": 1,
-        "name": "coverage",
+        "name": "code coverage analysis",
         "description": "This file is uncovered",
         "path": "my/path/header.h",
         "severity": "warning",

--- a/bot/tests/test_hash.py
+++ b/bot/tests/test_hash.py
@@ -6,9 +6,10 @@
 import hashlib
 
 from code_review_bot.tasks.lint import MozLintIssue
+from code_review_bot.tasks.lint import MozLintTask
 
 
-def test_build_hash(mock_revision, mock_hgmo):
+def test_build_hash(mock_revision, mock_hgmo, mock_task):
     """
     Test build hash algorithm
     """
@@ -17,7 +18,7 @@ def test_build_hash(mock_revision, mock_hgmo):
     mock_revision.mercurial_revision = "deadbeef1234"
 
     issue = MozLintIssue(
-        "mock-analyzer-eslint",
+        mock_task(MozLintTask, "mock-analyzer-eslint"),
         "path/to/file.cpp",
         42,
         "error",
@@ -43,7 +44,7 @@ def test_build_hash(mock_revision, mock_hgmo):
     assert hash_check == "045f57ef8ee111d0c8c475bd7a617564" == issue.build_hash()
 
 
-def test_indentation_effect(mock_revision, mock_hgmo):
+def test_indentation_effect(mock_revision, mock_hgmo, mock_task):
     """
     Test indentation does not affect the hash
     2 lines with same content in a file, triggering the same error
@@ -54,7 +55,7 @@ def test_indentation_effect(mock_revision, mock_hgmo):
     mock_revision.mercurial_revision = "deadbeef1234"
 
     issue_indent = MozLintIssue(
-        "mock-analyzer-flake8",
+        mock_task(MozLintTask, "mock-analyzer-flake8"),
         "hello1",
         2,
         "error",
@@ -65,7 +66,7 @@ def test_indentation_effect(mock_revision, mock_hgmo):
         mock_revision,
     )
     issue_no_indent = MozLintIssue(
-        "mock-analyzer-flake8",
+        mock_task(MozLintTask, "mock-analyzer-flake8"),
         "hello1",
         5,
         "error",
@@ -89,7 +90,7 @@ def test_indentation_effect(mock_revision, mock_hgmo):
     )
 
 
-def test_full_file(mock_revision, mock_hgmo):
+def test_full_file(mock_revision, mock_hgmo, mock_task):
     """
     Test build hash algorithm when using a full file (line is -1)
     """
@@ -98,7 +99,7 @@ def test_full_file(mock_revision, mock_hgmo):
     mock_revision.mercurial_revision = "deadbeef1234"
 
     issue = MozLintIssue(
-        "mock-analyzer-fullfile",
+        mock_task(MozLintTask, "mock-analyzer-fullfile"),
         "path/to/afile.py",
         0,
         "error",

--- a/bot/tests/test_infer.py
+++ b/bot/tests/test_infer.py
@@ -9,7 +9,7 @@ from code_review_bot.tasks.infer import InferTask
 from conftest import FIXTURES_DIR
 
 
-def test_as_text(mock_revision):
+def test_as_text(mock_revision, mock_task):
     """
     Test text export for InferIssue
     """
@@ -21,13 +21,13 @@ def test_as_text(mock_revision):
         "kind": "ERROR",
         "qualifier": "Error on this line",
     }
-    issue = InferIssue("mock-infer", parts, mock_revision)
+    issue = InferIssue(mock_task(InferTask, "mock-infer"), parts, mock_revision)
 
     expected = "Warning: Error on this line [infer: SOMETYPE]"
     assert issue.as_text() == expected
 
 
-def test_as_dict(mock_revision, mock_hgmo):
+def test_as_dict(mock_revision, mock_hgmo, mock_task):
     """
     Test dict export for InferIssue
     """
@@ -40,7 +40,7 @@ def test_as_dict(mock_revision, mock_hgmo):
         "kind": "WARNING",
         "qualifier": "Error on this line",
     }
-    issue = InferIssue("mock-infer", parts, mock_revision)
+    issue = InferIssue(mock_task(InferTask, "mock-infer"), parts, mock_revision)
 
     assert issue.as_dict() == {
         "analyzer": "mock-infer",
@@ -58,7 +58,7 @@ def test_as_dict(mock_revision, mock_hgmo):
     }
 
 
-def test_as_markdown(mock_revision):
+def test_as_markdown(mock_revision, mock_task):
     """
     Test markdown generation for InferIssue
     """
@@ -71,7 +71,7 @@ def test_as_markdown(mock_revision):
         "kind": "WARNING",
         "qualifier": "Error on this line",
     }
-    issue = InferIssue("mock-infer", parts, mock_revision)
+    issue = InferIssue(mock_task(InferTask, "mock-infer"), parts, mock_revision)
 
     assert (
         issue.as_markdown()

--- a/bot/tests/test_issues.py
+++ b/bot/tests/test_issues.py
@@ -4,9 +4,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from code_review_bot.tasks.clang_format import ClangFormatIssue
+from code_review_bot.tasks.clang_format import ClangFormatTask
 
 
-def test_allowed_paths(mock_config, mock_revision):
+def test_allowed_paths(mock_config, mock_revision, mock_task):
     """
     Test allowed paths for ClangFormatIssue
     The test config has these 2 rules: dom/* and tests/*.py
@@ -15,7 +16,9 @@ def test_allowed_paths(mock_config, mock_revision):
     def _allowed(path):
         # Build an issue and check its validation
         # that will trigger the path validation
-        issue = ClangFormatIssue("mock-clang-format", path, 1, 1, mock_revision)
+        issue = ClangFormatIssue(
+            mock_task(ClangFormatTask, "mock-clang-format"), path, 1, 1, mock_revision
+        )
         return issue.validates()
 
     checks = {
@@ -31,13 +34,17 @@ def test_allowed_paths(mock_config, mock_revision):
         assert _allowed(path) is result
 
 
-def test_backend_publication(mock_revision):
+def test_backend_publication(mock_revision, mock_task):
     """
     Test the backend publication status modifies an issue publication
     """
 
     issue = ClangFormatIssue(
-        "mock-clang-format", "dom/somefile.cpp", 1, 1, mock_revision
+        mock_task(ClangFormatTask, "mock-clang-format"),
+        "dom/somefile.cpp",
+        1,
+        1,
+        mock_revision,
     )
     assert issue.validates()
 

--- a/bot/tests/test_lint.py
+++ b/bot/tests/test_lint.py
@@ -11,14 +11,14 @@ from code_review_bot.tasks.lint import MozLintTask
 from conftest import FIXTURES_DIR
 
 
-def test_flake8_checks(mock_config, mock_revision, mock_hgmo):
+def test_flake8_checks(mock_config, mock_revision, mock_hgmo, mock_task):
     """
     Check flake8 check detection
     """
 
     # Valid issue
     issue = MozLintIssue(
-        "mock-lint-flake8",
+        mock_task(MozLintTask, "mock-lint-flake8"),
         "test.py",
         1,
         "error",
@@ -33,7 +33,7 @@ def test_flake8_checks(mock_config, mock_revision, mock_hgmo):
 
     # Flake8 bad quotes
     issue = MozLintIssue(
-        "mock-lint-flake8",
+        mock_task(MozLintTask, "mock-lint-flake8"),
         "test.py",
         1,
         "error",
@@ -62,13 +62,13 @@ def test_flake8_checks(mock_config, mock_revision, mock_hgmo):
     }
 
 
-def test_as_text(mock_config, mock_revision, mock_hgmo):
+def test_as_text(mock_config, mock_revision, mock_hgmo, mock_task):
     """
     Test text export for ClangTidyIssue
     """
 
     issue = MozLintIssue(
-        "mock-lint-flake8",
+        mock_task(MozLintTask, "mock-lint-flake8"),
         "test.py",
         1,
         "error",
@@ -137,5 +137,5 @@ def test_licence_payload(mock_revision, mock_hgmo):
         str(issue)
         == "source-test-mozlint-license issue source-test-mozlint-license@error intl/locale/rust/unic-langid-ffi/src/lib.rs full file"
     )
-    assert issue.check == issue.analyzer == "source-test-mozlint-license"
+    assert issue.check == issue.analyzer.name == "source-test-mozlint-license"
     assert issue.build_hash() == "0809d81e1e24ee94039c0e2733321a39"

--- a/bot/tests/test_patch.py
+++ b/bot/tests/test_patch.py
@@ -7,9 +7,12 @@ import responses
 
 from code_review_bot.config import settings
 from code_review_bot.revisions import ImprovementPatch
+from code_review_bot.tasks.default import DefaultTask
 
 
-def test_publication(monkeypatch, mock_taskcluster_config, mock_repositories):
+def test_publication(
+    monkeypatch, mock_taskcluster_config, mock_repositories, mock_task
+):
     """
     Check a patch publication through Taskcluster services
     """
@@ -28,7 +31,9 @@ def test_publication(monkeypatch, mock_taskcluster_config, mock_repositories):
         headers={"ETag": "test123"},
     )
 
-    patch = ImprovementPatch("mock-analyzer", "test-improvement", "This is good code")
+    patch = ImprovementPatch(
+        mock_task(DefaultTask, "mock-analyzer"), "test-improvement", "This is good code"
+    )
     assert patch.url is None
 
     patch.publish()

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -565,7 +565,7 @@ def test_clang_format_task(
     assert len(issues) == 1
     assert len(mock_revision.improvement_patches) == 1
     patch = mock_revision.improvement_patches[0]
-    assert patch.analyzer == "source-test-clang-format"
+    assert patch.analyzer.name == "source-test-clang-format"
     assert patch.content == "A nice diff in here..."
 
 

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -532,7 +532,7 @@ def test_clang_format_task(
         "analyzer": "source-test-clang-format",
         "check": "invalid-styling",
         "level": "warning",
-        "message": None,
+        "message": "Reformat C/C++",
         "column": 11,
         "in_patch": False,
         "line": 1386,
@@ -541,6 +541,15 @@ def test_clang_format_task(
         "publishable": False,
         "validates": False,
         "hash": "56f81d5190f8e1bd7a7d2380e7da6d67",
+    }
+    assert issue.as_phabricator_lint() == {
+        "char": 11,
+        "code": "invalid-styling",
+        "description": "Reformat C/C++",
+        "line": 1386,
+        "name": "clang-format",
+        "path": "test.cpp",
+        "severity": "warning",
     }
     assert len(mock_revision.improvement_patches) == 0
 

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -532,7 +532,7 @@ def test_clang_format_task(
         "analyzer": "source-test-clang-format",
         "check": "invalid-styling",
         "level": "warning",
-        "message": "Reformat C/C++",
+        "message": "The change does not follow the C/C++ coding style, please reformat",
         "column": 11,
         "in_patch": False,
         "line": 1386,
@@ -545,7 +545,7 @@ def test_clang_format_task(
     assert issue.as_phabricator_lint() == {
         "char": 11,
         "code": "invalid-styling",
-        "description": "Reformat C/C++",
+        "description": "The change does not follow the C/C++ coding style, please reformat",
         "line": 1386,
         "name": "clang-format",
         "path": "test.cpp",

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -58,7 +58,7 @@ Code analysis found 1 defect in the diff 42:
  - 1 defect found by py-flake8 (Mozlint)
 
 You can run this analysis locally with:
- - `./mach lint --warnings --outgoing` (JS/Python/etc)
+ - `./mach lint --warnings --outgoing`
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
 
@@ -103,7 +103,7 @@ Code analysis found 2 defects in the diff 42:
  - 2 defects found by dummy (Mozlint)
 
 You can run this analysis locally with:
- - `./mach lint --warnings --outgoing` (JS/Python/etc)
+ - `./mach lint --warnings --outgoing`
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
 

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -55,7 +55,7 @@ You can view these defects on [the code-review frontend](https://code-review.moz
 
 VALID_FLAKE8_MESSAGE = """
 Code analysis found 1 defect in the diff 42:
- - 1 defect found by py-flake8 (by MozLint)
+ - 1 defect found by py-flake8 (Mozlint)
 
 You can run this analysis locally with:
  - `./mach lint --warnings --outgoing` (JS/Python/etc)
@@ -100,7 +100,7 @@ If you see a problem in this automated review, [please report it here](https://b
 
 VALID_MOZLINT_MESSAGE = """
 Code analysis found 2 defects in the diff 42:
- - 2 defects found by dummy (by MozLint)
+ - 2 defects found by dummy (Mozlint)
 
 You can run this analysis locally with:
  - `./mach lint --warnings --outgoing` (JS/Python/etc)
@@ -254,7 +254,7 @@ def test_phabricator_mozlint(
                     "code": "EXXX",
                     "description": "A bad bad error",
                     "line": 42,
-                    "name": "py-flake8 (by MozLint)",
+                    "name": "py-flake8 (Mozlint)",
                     "path": "python/test.py",
                     "severity": "error",
                 }
@@ -776,7 +776,7 @@ def test_extra_errors(mock_phabricator, mock_try_task, phab, mock_task):
                     "code": "EYYY",
                     "description": "Some not so bad python mistake",
                     "line": 2,
-                    "name": "dummy (by MozLint)",
+                    "name": "dummy (Mozlint)",
                     "path": "path/to/file.py",
                     "severity": "warning",
                 },
@@ -785,7 +785,7 @@ def test_extra_errors(mock_phabricator, mock_try_task, phab, mock_task):
                     "code": "EXXX",
                     "description": "Some bad python typo",
                     "line": 10,
-                    "name": "dummy (by MozLint)",
+                    "name": "dummy (Mozlint)",
                     "path": "path/to/file.py",
                     "severity": "error",
                 },


### PR DESCRIPTION
Fixes #554

This PR allow us to customize the analyzer name displayed in Phabricator (and other parts of the system).
The `AnalysisTask` instances are now fully accessible from their issues (instead of a single string), which allows us to have some logic from the tasks accessible when building payloads for Phabricator.

Two new methods are available on the `AnalysisTask` sub classes:
- `build_help_message` customizes the optional help message in the summary comment
- `display_name` is a nicer name, only used for humans (:robot: still use the shorter and unique `name`).