### PR TITLE
Add a comment when errors are published outside of patch

### DIFF
--- a/bot/code_review_bot/report/base.py
+++ b/bot/code_review_bot/report/base.py
@@ -146,6 +146,11 @@ class Reporter(object):
         else:
             comment = ""
 
+        if not all(
+            revision.contains(issue) for issue in issues if issue.is_publishable()
+        ):
+            comment += "(defects might be in the parent stack)\n"
+
         # Add defects
         if defects:
             comment += "\n".join(defects) + "\n"

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -121,6 +121,7 @@ If you see a problem in this automated review, [please report it here](https://b
 
 VALID_MOZLINT_MESSAGE = """
 Code analysis found 2 defects in the diff 42:
+(defects might be in the parent stack)
  - 2 defects found by dummy (Mozlint)
 
 You can run this analysis locally with:


### PR DESCRIPTION
#553 
Added a comment when errors are published outside of patch.

**before**
Code analysis found X defects in the diff Y

**after**
Code analysis found X defects in the diff Y **(defects might be in the parent stack)**