### PR TITLE
Display build error as coverity name

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -102,6 +102,14 @@ class Issue(abc.ABC):
         line = f"line {self.line}" if self.line is not None else "full file"
         return f"{self.analyzer.name} issue {self.check}@{self.level.value} {self.path} {line}"
 
+    @property
+    def display_name(self):
+        """
+        Issue's base name (by default analyzer's name)
+        But can be overridden by subclasses
+        """
+        return self.analyzer.display_name
+
     def build_extra_identifiers(self):
         """
         Used to add information when building an issue unique hash
@@ -248,7 +256,7 @@ class Issue(abc.ABC):
         description = f"{prefix} {self.message}"
 
         return LintResult(
-            name=self.analyzer.display_name,
+            name=self.display_name,
             description=description,
             code=self.check,
             severity=self.level.value,

--- a/bot/code_review_bot/tasks/coverity.py
+++ b/bot/code_review_bot/tasks/coverity.py
@@ -45,7 +45,6 @@ class CoverityIssue(Issue):
     """
 
     def __init__(self, analyzer, revision, issue, file_path):
-        self.build_error = issue.get("build_error", False)
         super().__init__(
             analyzer,
             revision,
@@ -53,8 +52,7 @@ class CoverityIssue(Issue):
             line=issue["line"],
             nb_lines=1,
             check=issue["flag"],
-            # Report build errors as Error
-            level=Level.Error if self.build_error else Level.Warning,
+            level=Level.Warning,
             message=issue["message"],
         )
         self.reliability = (
@@ -62,8 +60,15 @@ class CoverityIssue(Issue):
             if "reliability" in issue
             else Reliability.Unknown
         )
+        self.build_error = issue.get("build_error", False)
 
         self.state_on_server = issue["extra"]["stateOnServer"]
+
+        # For build errors we don't embed the stack into the message
+        if self.build_error:
+            # For build errors report them as errors
+            self.level = Level.Error
+            return
 
         # If we have `stack` in the `try` result then embed it in the message.
         if "stack" in issue["extra"]:

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -685,14 +685,28 @@ The path that leads to this defect is:
     assert issue.check == "UNINIT"
     assert issue.reliability == Reliability.High
     assert issue.build_error
-    assert issue.message == "Some error here"
+    assert (
+        issue.message
+        == """Some error here
+The path that leads to this defect is:
+
+- //dom/animation/Animation.cpp:61//:
+-- `path: Condition "!target.oper…", taking false branch.`.
+"""
+    )
     assert issue.is_local()
     assert not issue.is_clang_error()
     assert issue.validates()
     assert issue.is_build_error()
     assert (
         issue.as_text()
-        == f"Checker reliability is high, meaning that the false positive ratio is low.\nSome error here"
+        == f"""Checker reliability is high, meaning that the false positive ratio is low.
+Some error here
+The path that leads to this defect is:
+
+- //dom/animation/Animation.cpp:61//:
+-- `path: Condition "!target.oper…", taking false branch.`.
+"""
     )
 
     assert check_stats(

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -685,15 +685,7 @@ The path that leads to this defect is:
     assert issue.check == "UNINIT"
     assert issue.reliability == Reliability.High
     assert issue.build_error
-    assert (
-        issue.message
-        == """Some error here
-The path that leads to this defect is:
-
-- //dom/animation/Animation.cpp:61//:
--- `path: Condition "!target.oper…", taking false branch.`.
-"""
-    )
+    assert issue.message == "Some error here"
     assert issue.is_local()
     assert not issue.is_clang_error()
     assert issue.validates()
@@ -701,12 +693,7 @@ The path that leads to this defect is:
     assert (
         issue.as_text()
         == f"""Checker reliability is high, meaning that the false positive ratio is low.
-Some error here
-The path that leads to this defect is:
-
-- //dom/animation/Animation.cpp:61//:
--- `path: Condition "!target.oper…", taking false branch.`.
-"""
+Some error here"""
     )
 
     assert check_stats(

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -735,7 +735,7 @@ def test_phabricator_coverity_build_error(
                         "description": '(IMPORTANT) ERROR: Dereferencing a pointer that might be "nullptr" '
                         '"env" when calling "lookupImport".',
                         "line": 41,
-                        "name": "Coverity",
+                        "name": "Build Error",
                         "path": "test.cpp",
                         "severity": "error",
                     }


### PR DESCRIPTION
It will display `Build Error` as lint name, when a Coverity issue is a build error (defaulting to `Coverity` otherwise).

I also added the stack to the build error reporting, now that we use a lint result, it can be shown without breaking the display