### PR TITLE
Display build error & defects stats in summary comment

### DIFF
--- a/bot/tests/test_reporter_mail.py
+++ b/bot/tests/test_reporter_mail.py
@@ -130,6 +130,8 @@ def test_mail(
             "total": 5,
             "publishable": 3,
             "publishable_paths": ["/path/to/file"],
+            "nb_build_errors": 2,
+            "nb_defects": 1,
         }
     ]
 

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -49,9 +49,7 @@ You can view these defects on [the code-review frontend](https://code-review.moz
 
 VALID_COVERITY_BUILD_ERROR_MESSAGE = """
 Code analysis found 1 defect in the diff 42:
- - 1 defect found by Coverity
-
-IMPORTANT: 1 build error detected.
+ - 1 build error found by Coverity
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
 


### PR DESCRIPTION
This will display detailed stats in the summary comments:

- 1 build error found by XX
- 1 build error and 2 defects found by YY
- 3 defects found by ZZ