### PR TITLE
Fix bug preventing report serialization

### DIFF
--- a/bot/code_review_bot/report/debug.py
+++ b/bot/code_review_bot/report/debug.py
@@ -48,7 +48,7 @@ class DebugReporter(Reporter):
             "revision": revision.as_dict(),
             "issues": [issue.as_dict() for issue in issues],
             "patches": {
-                patch.analyzer: patch.url or patch.path
+                patch.analyzer.name: patch.url or patch.path
                 for patch in revision.improvement_patches
             },
             "task_failures": [


### PR DESCRIPTION
This bug crashes the final execution of the bot when a clang-format is present (the debug reporter crashes, and i'm lucky this is the ultimate step in the bot, nothing is really affected.)