### PR TITLE
Use selectedTaskRun instead of selectedJob for the Treeherder link pointing to a given task

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 known_first_party = code_review_backend,code_review_bot,code_review_tools,code_review_events,conftest
-known_third_party = dj_database_url,django,drf_yasg,influxdb,jsone,jsonschema,libmozdata,libmozevent,logbook,parsepatch,pytest,raven,requests,responses,rest_framework,rs_parsepatch,sentry_sdk,setuptools,slugid,structlog,taskcluster,thclient,yaml
+known_third_party = dj_database_url,django,drf_yasg,influxdb,jsone,jsonschema,libmozdata,libmozevent,logbook,parsepatch,pytest,raven,requests,responses,rest_framework,rs_parsepatch,sentry_sdk,setuptools,structlog,taskcluster,yaml
 force_single_line = True
 default_section=FIRSTPARTY
 line_length=159

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -653,16 +653,6 @@ def mock_backend(mock_backend_secret):
     return revisions, diffs, issues
 
 
-@pytest.fixture
-def mock_treeherder():
-    responses.add(
-        responses.GET,
-        "https://treeherder.mozilla.org/api/jobdetail/",
-        body=json.dumps({"results": [{"job_id": 1234}]}),
-        content_type="application/json",
-    )
-
-
 class MockPhabricator(object):
     """
     A Mock Phabricator API server using responses

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -110,7 +110,7 @@ You can view these defects on [the code-review frontend](https://code-review.moz
 """
 
 VALID_TASK_FAILURES_MESSAGE = """
-The analysis task [mock-infer](https://treeherder.mozilla.org/#/jobs?repo=try&revision=aabbccddee&selectedJob=1234) failed, but we could not detect any issue.
+The analysis task [mock-infer](https://treeherder.mozilla.org/#/jobs?repo=try&revision=aabbccddee&selectedTaskRun=ab3NrysvSZyEwsOHL2MZfw-0) failed, but we could not detect any issue.
 Please check this task manually.
 
 If you see a problem in this automated review, [please report it here](https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox+Build+System&component=Source+Code+Analysis&short_desc=[Automated+review]+UPDATE&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__).
@@ -819,7 +819,7 @@ def test_full_file(mock_config, mock_phabricator, phab, mock_try_task, mock_task
     ]
 
 
-def test_task_failures(mock_phabricator, phab, mock_try_task, mock_treeherder):
+def test_task_failures(mock_phabricator, phab, mock_try_task):
     """
     Test Phabricator reporter publication with some task failures
     """

--- a/events/tests/test_bugbug_utils.py
+++ b/events/tests/test_bugbug_utils.py
@@ -496,7 +496,7 @@ async def test_got_bugbug_test_select_end(PhabricatorMock, mock_taskcluster):
 
 
 @pytest.mark.asyncio
-async def test_got_try_task_end(PhabricatorMock, mock_taskcluster, mock_treeherder):
+async def test_got_try_task_end(PhabricatorMock, mock_taskcluster):
     bus = MessageBus()
     build = PhabricatorBuild(
         MockRequest(
@@ -605,40 +605,13 @@ async def test_got_try_task_end(PhabricatorMock, mock_taskcluster, mock_treeherd
         "details": None,
     }
 
-    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
-        rsps.add(
-            responses.GET,
-            "https://treeherder.mozilla.org/api/jobdetail/?job_guid=5b648c67-76d8-4de6-a706-af9636951e1c/0",
-            body=mock_treeherder("jobdetail.json"),
-            content_type="application/json",
-        )
-
-        payload["body"]["status"]["state"] = "failed"
-        await bugbug_utils.got_try_task_end(payload)
-        mode, build_, extras = await bus.receive(QUEUE_PHABRICATOR_RESULTS)
-        assert mode == "test_result"
-        assert build_ == build
-        assert extras == {
-            "name": "test-linux64-shippable/opt-awsy-tp6-e10s",
-            "result": UnitResultState.Fail,
-            "details": "https://treeherder.mozilla.org/#/jobs?repo=try&revision=028980a035fb3e214f7645675a01a52234aad0fe&selectedJob=277665740",
-        }
-
-    with responses.RequestsMock(assert_all_requests_are_fired=True) as rsps:
-        rsps.add(
-            responses.GET,
-            "https://treeherder.mozilla.org/api/jobdetail/?job_guid=5b648c67-76d8-4de6-a706-af9636951e1c/0",
-            body=mock_treeherder("jobdetail_empty.json"),
-            content_type="application/json",
-        )
-
-        payload["body"]["status"]["state"] = "failed"
-        await bugbug_utils.got_try_task_end(payload)
-        mode, build_, extras = await bus.receive(QUEUE_PHABRICATOR_RESULTS)
-        assert mode == "test_result"
-        assert build_ == build
-        assert extras == {
-            "name": "test-linux64-shippable/opt-awsy-tp6-e10s",
-            "result": UnitResultState.Fail,
-            "details": "https://treeherder.mozilla.org/#/jobs?repo=try&revision=028980a035fb3e214f7645675a01a52234aad0fe",
-        }
+    payload["body"]["status"]["state"] = "failed"
+    await bugbug_utils.got_try_task_end(payload)
+    mode, build_, extras = await bus.receive(QUEUE_PHABRICATOR_RESULTS)
+    assert mode == "test_result"
+    assert build_ == build
+    assert extras == {
+        "name": "test-linux64-shippable/opt-awsy-tp6-e10s",
+        "result": UnitResultState.Fail,
+        "details": "https://treeherder.mozilla.org/#/jobs?repo=try&revision=028980a035fb3e214f7645675a01a52234aad0fe&selectedTaskRun=W2SMZ3bYTeanBq-WNpUeHA-0",
+    }

--- a/tools/code_review_tools/treeherder.py
+++ b/tools/code_review_tools/treeherder.py
@@ -2,9 +2,6 @@
 
 from urllib.parse import urlencode
 
-import slugid
-from thclient import TreeherderClient
-
 JOBS_URL = "https://treeherder.mozilla.org/#/jobs"
 
 
@@ -18,12 +15,6 @@ def get_job_url(repository, revision, task_id=None, run_id=None, **params):
     params.update({"repo": repository, "revision": revision})
 
     if task_id is not None and run_id is not None:
-        treeherder_client = TreeherderClient()
-        uuid = slugid.decode(task_id)
-
-        # Fetch specific job id from treeherder
-        job_details = treeherder_client.get_job_details(job_guid=f"{uuid}/{run_id}")
-        if len(job_details) > 0:
-            params["selectedJob"] = job_details[0]["job_id"]
+        params["selectedTaskRun"] = f"{task_id}-{run_id}"
 
     return f"{JOBS_URL}?{urlencode(params)}"


### PR DESCRIPTION
This way we can avoid a API call to Treeherder.

This capability was recently added to Treeherder in https://bugzilla.mozilla.org/show_bug.cgi?id=1605426.

Fixes #371