### PR TITLE
bot: For C++ build error reporting stop using `Coverity` that proved to be suboptimal and use `clang-tidy` for this.

### DIFF
--- a/bot/code_review_bot/tasks/coverity.py
+++ b/bot/code_review_bot/tasks/coverity.py
@@ -94,12 +94,6 @@ class CoverityIssue(Issue):
             return "Build Error"
         return self.analyzer.display_name
 
-    def is_clang_error(self):
-        """
-        Determine if the current issue is a translation unit error forwarded by Clang
-        """
-        return "RW.CLANG" in self.check
-
     def is_local(self):
         """
         The given coverity issue should be only locally stored and not in the
@@ -139,7 +133,7 @@ class CoverityIssue(Issue):
             publishable=self.is_publishable() and "yes" or "no",
             is_local=self.is_local() and "yes" or "no",
             reliability=self.reliability.value,
-            is_clang_error=self.is_clang_error() and "yes" or "no",
+            is_clang_error=self.is_build_error() and "yes" or "no",
         )
 
     def as_error(self):

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -21,6 +21,8 @@ from libmozdata.phabricator import PhabricatorAPI
 from code_review_bot import stats
 from code_review_bot.backend import BackendAPI
 from code_review_bot.config import settings
+from code_review_bot.tasks.clang_tidy import ClangTidyIssue
+from code_review_bot.tasks.clang_tidy import ClangTidyTask
 from code_review_bot.tasks.coverity import CoverityIssue
 from code_review_bot.tasks.coverity import CoverityTask
 from code_review_bot.tasks.default import DefaultTask
@@ -123,6 +125,30 @@ def mock_coverity_issues(mock_revision, mock_task):
                 "flag": "flag",
             },
             "some/file/path",
+        )
+        for i in range(2)
+    ]
+
+
+@pytest.fixture
+def mock_clang_tidy_issues(mock_revision, mock_task):
+    """
+    Build a list of clang-tidy issues
+    """
+
+    from code_review_bot import Level
+
+    return [
+        ClangTidyIssue(
+            analyzer=mock_task(ClangTidyTask, "mock-clang-tidy"),
+            revision=mock_revision,
+            path="dom/animation/Animation.cpp",
+            line=57,
+            column=46,
+            level=Level("error") if i % 2 else Level("warning"),
+            check="clanck.checker",
+            message="Some Error Message",
+            publish=True,
         )
         for i in range(2)
     ]

--- a/bot/tests/test_clang.py
+++ b/bot/tests/test_clang.py
@@ -80,6 +80,7 @@ def test_as_dict(mock_revision, mock_hgmo, mock_task):
     """
     Test text export for ClangTidyIssue
     """
+    from code_review_bot import Level
     from code_review_bot import Reliability
 
     issue = ClangTidyIssue(
@@ -90,6 +91,7 @@ def test_as_dict(mock_revision, mock_hgmo, mock_task):
         "51",
         "dummy-check",
         "dummy message withUppercaseChars",
+        Level.Warning,
         Reliability.Low,
     )
 
@@ -114,6 +116,7 @@ def test_as_markdown(mock_revision, mock_task):
     """
     Test markdown generation for ClangTidyIssue
     """
+    from code_review_bot import Level
     from code_review_bot import Reliability
 
     issue = ClangTidyIssue(
@@ -124,6 +127,7 @@ def test_as_markdown(mock_revision, mock_task):
         "51",
         "dummy-check",
         "dummy message",
+        Level.Warning,
         Reliability.High,
     )
 

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -425,7 +425,8 @@ def test_clang_tidy_task(mock_config, mock_revision, mock_workflow, mock_backend
                                     {
                                         "column": 51,
                                         "line": 987,
-                                        "flag": "checker.YYY",
+                                        "type": "error",
+                                        "flag": "clang-diagnostic-error",
                                         # No reliability !
                                         "message": "some harder issue with c++",
                                         "filename": "test.cpp",
@@ -448,16 +449,17 @@ def test_clang_tidy_task(mock_config, mock_revision, mock_workflow, mock_backend
     assert issue.check == "checker.XXX"
     assert issue.reliability == Reliability.High
     assert issue.message == "some hard issue with c++"
+    assert not issue.is_build_error()
 
     issue = issues[1]
     assert isinstance(issue, ClangTidyIssue)
     assert issue.path == "test.cpp"
     assert issue.line == 987
     assert issue.column == 51
-    assert issue.check == "checker.YYY"
+    assert issue.check == "clang-diagnostic-error"
     assert issue.reliability == Reliability.Unknown
     assert issue.message == "some harder issue with c++"
-
+    assert issue.is_build_error()
     assert check_stats(
         [
             ("code-review.analysis.files", None, 2),
@@ -668,7 +670,6 @@ The path that leads to this defect is:
 -- `path: Condition \"!target.oper…", taking false branch.`.\n"""
     )
     assert issue.is_local()
-    assert not issue.is_clang_error()
     assert issue.validates()
     assert not issue.is_build_error()
 
@@ -678,10 +679,8 @@ The path that leads to this defect is:
     assert issue.line == 123
     assert issue.check == "UNINIT"
     assert issue.reliability == Reliability.High
-    assert issue.build_error
     assert issue.message == "Some error here"
     assert issue.is_local()
-    assert not issue.is_clang_error()
     assert issue.validates()
     assert issue.is_build_error()
     assert (

--- a/bot/tests/test_reporter_mail.py
+++ b/bot/tests/test_reporter_mail.py
@@ -137,10 +137,43 @@ def test_mail(
 
 
 def test_mail_builderrors(
-    log, mock_config, mock_coverity_issues, mock_revision, mock_taskcluster_config
+    log, mock_config, mock_clang_tidy_issues, mock_revision, mock_taskcluster_config
 ):
     """
     Test mail_builderrors sending through Taskcluster
+    """
+    from code_review_bot.report.mail_builderrors import BuildErrorsReporter
+
+    def _check_email(request):
+        payload = json.loads(request.body)
+
+        assert payload["subject"] == "Code Review bot found 2 build errors on D51"
+        assert payload["address"] == "test@mozilla.com"
+        assert payload["content"] == MAIL_CONTENT_BUILD_ERRORS
+
+        return (200, {}, "")  # ack
+
+    # Add mock taskcluster email to check output
+    responses.add_callback(
+        responses.POST,
+        "http://taskcluster.test/api/notify/v1/email",
+        callback=_check_email,
+    )
+
+    # Publish email
+    conf = {"emails": ["test@mozilla.com"]}
+    r = BuildErrorsReporter(conf)
+
+    r.publish(mock_clang_tidy_issues, mock_revision, [])
+
+    assert log.has("Send build error email", to="test@mozilla.com")
+
+
+def test_mail_builderrors_coverity(
+    log, mock_config, mock_coverity_issues, mock_revision, mock_taskcluster_config
+):
+    """
+    Test mail_builderrors sending through Taskcluster for coverity
     """
     from code_review_bot.report.mail_builderrors import BuildErrorsReporter
 


### PR DESCRIPTION
`Coverity` proved to be suboptimal when we want to detect build errors so we must stop using it and switch to `clang-tooling`, in this case `clang-tidy`.