### PR TITLE
Rename the link to Treeherder from 'Treeherder Jobs' to 'CI (Treeherder) Jobs'

### DIFF
--- a/docs/publication.md
+++ b/docs/publication.md
@@ -36,7 +36,7 @@ We have [plans](https://bugzilla.mozilla.org/show_bug.cgi?id=1555721) to remove 
 ## Troubleshooting
 
 1. Check that your task is triggered by the decision task on new diffs
-2. Check that your task is present in the task group published by the code review bot as `Treeherder jobs`
+2. Check that your task is present in the task group published by the code review bot as `CI (Treeherder) Jobs`
 3. Check that your task produces the expected analysis artifact
 4. Check that the `code-review-issues` is present in that task group (for mozilla-central tasks)
 5. Check that your test diff is available on [our dashboard](https://code-review.moz.tools/) by searching its revision ID or title (it can take several seconds to load all the tasks available)

--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -202,7 +202,7 @@ class CodeReview(PhabricatorActions):
             self.api.create_harbormaster_uri(
                 build.target_phid,
                 "treeherder",
-                "Treeherder Jobs",
+                "CI (Treeherder) Jobs",
                 extras["treeherder_url"],
             )
 

--- a/events/tests/fixtures/taskcluster/task-gecko-decision.json
+++ b/events/tests/fixtures/taskcluster/task-gecko-decision.json
@@ -85,7 +85,7 @@
     "notify": {
       "email": {
         "link": {
-          "text": "Treeherder Jobs",
+          "text": "CI (Treeherder) Jobs",
           "href": "https://treeherder.mozilla.org/#/jobs?repo=try&revision=eec1748dad2ec002e4d9c71f926ccb67a3b88d73"
         },
         "subject": "Thank you for your try submission of eec1748dad2ec002e4d9c71f926ccb67a3b88d73. It's the best!",


### PR DESCRIPTION
Treeherder is a code name for a Mozilla project
CI is the actual wording for this