### PR TITLE
Add support for source-test-clang-tidy-external

### DIFF
--- a/bot/code_review_bot/report/base.py
+++ b/bot/code_review_bot/report/base.py
@@ -5,6 +5,7 @@
 
 import itertools
 
+from code_review_bot.tasks.clang_tidy_external import ExternalTidyIssue
 from code_review_bot.tasks.coverage import CoverageIssue
 from code_review_tools import treeherder
 
@@ -168,6 +169,11 @@ class Reporter(object):
 
         if analyzers:
             comment += COMMENT_RUN_ANALYZERS.format(analyzers="\n".join(analyzers))
+
+        for tidy_external_issue in filter(
+            lambda i: isinstance(i, ExternalTidyIssue), issues
+        ):
+            comment += tidy_external_issue.as_markdown_for_phab()
 
         for patch in patches:
             comment += COMMENT_DIFF_DOWNLOAD.format(

--- a/bot/code_review_bot/tasks/clang_tidy_external.py
+++ b/bot/code_review_bot/tasks/clang_tidy_external.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+
+import structlog
+
+from code_review_bot import Level
+from code_review_bot import Reliability
+from code_review_bot.tasks.clang_tidy import ClangTidyIssue
+from code_review_bot.tasks.clang_tidy import ClangTidyTask
+
+logger = structlog.get_logger(__name__)
+
+
+ISSUE_MARKDOWN = """
+#### Private Static Analysis {level}
+
+- **Message**: {message}
+- **Location**: {location}
+- **Clang check**: {check}
+- **in an expanded Macro**: {expanded_macro}
+
+{notes}"""
+
+ISSUE_NOTE_MARKDOWN = """
+- **Note**: {message}
+- **Location**: {location}
+
+```
+{body}
+```
+"""
+
+ERROR_MARKDOWN = """
+**Message**: ```{message}```
+**Location**: {location}
+"""
+
+CLANG_MACRO_DETECTION = re.compile(r"^expanded from macro")
+
+
+class ExternalTidyIssue(ClangTidyIssue):
+    """
+    An issue reported by source-test-clang-tidy-external
+    """
+
+    def as_error(self):
+        assert self.is_build_error(), "ExternalTidyIssue is not a build error."
+
+        return ERROR_MARKDOWN.format(
+            message=self.message, location="{}:{}".format(self.path, self.line)
+        )
+
+    def is_expanded_macro(self):
+        """
+        Is the issue only found in an expanded macro ?
+        """
+        if not self.notes:
+            return False
+
+        # Only consider first note
+        note = self.notes[0]
+        return CLANG_MACRO_DETECTION.match(note.message) is not None
+
+    def as_text(self):
+        """
+        Build the text body published on reporters
+        """
+        message = self.message
+        if len(message) > 0:
+            message = message[0].capitalize() + message[1:]
+        body = "{}: {} [external-tidy: {}]".format(self.level.name, message, self.check)
+
+        # Always add body as it's been cleaned up
+        if self.reason:
+            body += "\n{}".format(self.reason)
+        return body
+
+    def as_markdown_for_phab(self):
+        # skip not in patch or not publishable
+        if not self.revision.contains(self) or not self.is_publishable():
+            return ""
+
+        return ISSUE_MARKDOWN.format(
+            level=self.level.value,
+            message=self.message,
+            location="{}:{}:{}".format(self.path, self.line, self.column),
+            check=self.check,
+            expanded_macro="yes" if self.is_expanded_macro() else "no",
+            notes="\n".join(
+                [
+                    ISSUE_NOTE_MARKDOWN.format(
+                        message=n.message,
+                        location="{}:{}:{}".format(n.path, n.line, n.column),
+                        body=n.body,
+                    )
+                    for n in self.notes
+                ]
+            ),
+        )
+
+    def as_markdown(self):
+        return ISSUE_MARKDOWN.format(
+            level=self.level.value,
+            message=self.message,
+            location="{}:{}:{}".format(self.path, self.line, self.column),
+            reason=self.reason,
+            check=self.check,
+            in_patch="yes" if self.revision.contains(self) else "no",
+            publishable_check="yes" if self.has_publishable_check() else "no",
+            publishable="yes" if self.is_publishable() else "no",
+            expanded_macro="yes" if self.is_expanded_macro() else "no",
+            reliability=self.reliability.value,
+            notes="\n".join(
+                [
+                    ISSUE_NOTE_MARKDOWN.format(
+                        message=n.message,
+                        location="{}:{}:{}".format(n.path, n.line, n.column),
+                        body=n.body,
+                    )
+                    for n in self.notes
+                ]
+            ),
+        )
+
+
+class ExternalTidyTask(ClangTidyTask):
+    """
+    Support issues from source-test clang-tidy-external tasks
+    """
+
+    # Note this is currently in fact using the same file name as the
+    # normal clang tidy check, but this does NOT pose a problem
+    # as artifact names are separated into individual folders per task id.
+    artifacts = ["public/code-review/clang-tidy.json"]
+
+    @property
+    def display_name(self):
+        return "private static analysis"
+
+    def build_help_message(self, files):
+        return "Unfortunately, private static analysis can not be reproduced locally."
+
+    def parse_issues(self, artifacts, revision):
+        issues = [
+            ExternalTidyIssue(
+                analyzer=self,
+                revision=revision,
+                path=path,
+                line=warning["line"],
+                column=warning["column"],
+                check=warning["flag"],
+                level=Level(warning.get("type", "warning")),
+                message=warning["message"],
+                reliability=Reliability(warning["reliability"])
+                if "reliability" in warning
+                else Reliability.Unknown,
+                reason=warning.get("reason"),
+                publish=warning.get("publish"),
+            )
+            for artifact in artifacts.values()
+            for path, items in artifact["files"].items()
+            for warning in items["warnings"]
+        ]
+        return issues

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -20,6 +20,7 @@ from code_review_bot.revisions import Revision
 from code_review_bot.tasks.base import AnalysisTask
 from code_review_bot.tasks.clang_format import ClangFormatTask
 from code_review_bot.tasks.clang_tidy import ClangTidyTask
+from code_review_bot.tasks.clang_tidy_external import ExternalTidyTask
 from code_review_bot.tasks.coverage import ZeroCoverageTask
 from code_review_bot.tasks.coverity import CoverityTask
 from code_review_bot.tasks.default import DefaultTask
@@ -398,6 +399,8 @@ class Workflow(object):
             return InferTask(task_id, task_status)
         elif name == "source-test-doc-upload":
             return DocUploadTask(task_id, task_status)
+        elif name == "source-test-clang-tidy-external":
+            return ExternalTidyTask(task_id, task_status)
         elif settings.autoland_group_id is not None and not name.startswith(
             "source-test-"
         ):

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -12,6 +12,7 @@ from code_review_bot.config import Settings
 from code_review_bot.revisions import Revision
 from code_review_bot.tasks.clang_format import ClangFormatTask
 from code_review_bot.tasks.clang_tidy import ClangTidyTask
+from code_review_bot.tasks.clang_tidy_external import ExternalTidyTask
 from code_review_bot.tasks.coverity import CoverityTask
 from code_review_bot.tasks.default import DefaultTask
 from code_review_bot.tasks.infer import InferTask
@@ -87,6 +88,8 @@ def test_taskcluster_index(mock_config, mock_workflow, mock_try_task):
     [
         ("source-test-clang-tidy", ClangTidyTask, False),
         ("source-test-clang-tidy", ClangTidyTask, True),
+        ("source-test-clang-tidy-external", ExternalTidyTask, False),
+        ("source-test-clang-tidy-external", ExternalTidyTask, True),
         ("source-test-mozlint-eslint", MozLintTask, False),
         ("source-test-mozlint-eslint", MozLintTask, True),
         ("source-test-mozlint-whatever", MozLintTask, False),


### PR DESCRIPTION
This adds support for new static analysis, called "source-test-clang-tidy-external", which we are enabling in [Bug 1666808](https://bugzilla.mozilla.org/show_bug.cgi?id=1666808) (see also changeset in [phab](https://phabricator.services.mozilla.com/D91149)).


It works locally and pytest & flake8 pass, but I'm sure there's going to be some iteration.

The reported message looks like this, happy to modify to make it work for you folks.
![image](https://user-images.githubusercontent.com/5418775/94279702-c53e1900-ff4c-11ea-9c8e-ce8426ccb72c.png)
