### PR TITLE
Improve test coverage for clang-tidy-external

### DIFF
--- a/bot/code_review_bot/tasks/clang_tidy_external.py
+++ b/bot/code_review_bot/tasks/clang_tidy_external.py
@@ -42,10 +42,12 @@ ERROR_MARKDOWN = """
 
 CLANG_MACRO_DETECTION = re.compile(r"^expanded from macro")
 
+BUILD_HELP_MSG = """For private static analysis, please see [our private docs in Mana](https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=130909687), if you cannot access this resource, ask your reviewer to help you resolve the issue."""
+
 
 class ExternalTidyIssue(ClangTidyIssue):
     """
-    An issue reported by source-test-clang-tidy-external
+    An issue reported by source-test-clang-external
     """
 
     def as_error(self):
@@ -130,7 +132,7 @@ class ExternalTidyIssue(ClangTidyIssue):
 
 class ExternalTidyTask(ClangTidyTask):
     """
-    Support issues from source-test clang-tidy-external tasks
+    Support issues from source-test clang-external tasks
     """
 
     # Note this is currently in fact using the same file name as the
@@ -143,7 +145,7 @@ class ExternalTidyTask(ClangTidyTask):
         return "private static analysis"
 
     def build_help_message(self, files):
-        return "Unfortunately, private static analysis can not be reproduced locally."
+        return BUILD_HELP_MSG
 
     def parse_issues(self, artifacts, revision):
         issues = [
@@ -160,7 +162,8 @@ class ExternalTidyTask(ClangTidyTask):
                 if "reliability" in warning
                 else Reliability.Unknown,
                 reason=warning.get("reason"),
-                publish=warning.get("publish"),
+                publish=warning.get("publish")
+                and warning["flag"].startswith("mozilla-civet-"),
             )
             for artifact in artifacts.values()
             for path, items in artifact["files"].items()

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -399,7 +399,7 @@ class Workflow(object):
             return InferTask(task_id, task_status)
         elif name == "source-test-doc-upload":
             return DocUploadTask(task_id, task_status)
-        elif name == "source-test-clang-tidy-external":
+        elif name == "source-test-clang-external":
             return ExternalTidyTask(task_id, task_status)
         elif settings.autoland_group_id is not None and not name.startswith(
             "source-test-"

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -820,7 +820,7 @@ def test_external_tidy_task(mock_config, mock_revision, mock_workflow, mock_back
             },
             "remoteTryTask": {"dependencies": ["clang-tidy-external"]},
             "clang-tidy-external": {
-                "name": "source-test-clang-tidy-external",
+                "name": "source-test-clang-external",
                 "state": "completed",
                 "artifacts": {
                     "public/code-review/clang-tidy.json": {
@@ -833,10 +833,9 @@ def test_external_tidy_task(mock_config, mock_revision, mock_workflow, mock_back
                                         "line": 12,
                                         "column": 34,
                                         "message": "some hard issue with c++",
-                                        "flag": "checker.XXX",
+                                        "flag": "mozilla-civet-private-checker-1",
                                         "type": "warning",
                                         "reliability": "high",
-                                        "publish": True,
                                     },
                                 ],
                             }
@@ -853,7 +852,7 @@ def test_external_tidy_task(mock_config, mock_revision, mock_workflow, mock_back
     assert issue.path == "test.cpp"
     assert issue.line == 12
     assert issue.column == 34
-    assert issue.check == "checker.XXX"
+    assert issue.check == "mozilla-civet-private-checker-1"
     assert issue.reliability == Reliability.High
     assert issue.message == "some hard issue with c++"
     assert not issue.is_build_error()
@@ -862,9 +861,9 @@ def test_external_tidy_task(mock_config, mock_revision, mock_workflow, mock_back
         [
             ("code-review.analysis.files", None, 2),
             ("code-review.analysis.lines", None, 2),
-            ("code-review.issues", "source-test-clang-tidy-external", 1),
-            ("code-review.issues.publishable", "source-test-clang-tidy-external", 0),
-            ("code-review.issues.paths", "source-test-clang-tidy-external", 1),
+            ("code-review.issues", "source-test-clang-external", 1),
+            ("code-review.issues.publishable", "source-test-clang-external", 0),
+            ("code-review.issues.paths", "source-test-clang-external", 1),
             ("code-review.analysis.issues.publishable", None, 0),
             ("code-review.runtime.reports", None, "runtime"),
         ]

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -88,8 +88,8 @@ def test_taskcluster_index(mock_config, mock_workflow, mock_try_task):
     [
         ("source-test-clang-tidy", ClangTidyTask, False),
         ("source-test-clang-tidy", ClangTidyTask, True),
-        ("source-test-clang-tidy-external", ExternalTidyTask, False),
-        ("source-test-clang-tidy-external", ExternalTidyTask, True),
+        ("source-test-clang-external", ExternalTidyTask, False),
+        ("source-test-clang-external", ExternalTidyTask, True),
         ("source-test-mozlint-eslint", MozLintTask, False),
         ("source-test-mozlint-eslint", MozLintTask, True),
         ("source-test-mozlint-whatever", MozLintTask, False),


### PR DESCRIPTION
This patch adds testing for the case in which clang-tidy-external does not report clang-diagnostic errors,
which ought to be caught by the other clang-tidy jobs or during built.

We also improve reporting logic to ensure that only `mozilla-civet`-prefixed
diagnotics are reported.