### PR TITLE
bot: for clang_tidy_external do not report build-errors.

### DIFF
--- a/bot/code_review_bot/tasks/clang_tidy_external.py
+++ b/bot/code_review_bot/tasks/clang_tidy_external.py
@@ -50,6 +50,9 @@ class ExternalTidyIssue(ClangTidyIssue):
     An issue reported by source-test-clang-external
     """
 
+    def is_build_error(self):
+        return False
+
     def as_error(self):
         assert self.is_build_error(), "ExternalTidyIssue is not a build error."
 


### PR DESCRIPTION
Prevent a false-positive that this reporter generates.
This is a temporary fix, untill the underlying issue is fixed.