### PR TITLE
Add lando warnings support

### DIFF
--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -9,6 +9,7 @@ import sys
 
 import structlog
 import yaml
+from libmozdata.lando import LandoWarnings
 from libmozdata.phabricator import BuildState
 from libmozdata.phabricator import PhabricatorAPI
 
@@ -108,6 +109,16 @@ def main():
     phabricator_api = PhabricatorAPI(phabricator["api_key"], phabricator["url"])
     if phabricator_reporting_enabled:
         reporters["phabricator"].setup_api(phabricator_api)
+
+    # lando the Lando API
+    lando_reporting_enabled = "lando" in reporters
+    if lando_reporting_enabled:
+        if taskcluster.secrets["LANDO"].get("publish", False):
+            lando_api = LandoWarnings(
+                api_url=taskcluster.secrets["LANDO"]["url"],
+                api_key=phabricator["api_key"],
+            )
+            reporters["lando"].setup_api(lando_api)
 
     # Load unique revision
     try:

--- a/bot/code_review_bot/report/__init__.py
+++ b/bot/code_review_bot/report/__init__.py
@@ -5,6 +5,7 @@
 
 import structlog
 
+from code_review_bot.report.lando import LandoReporter
 from code_review_bot.report.mail import MailReporter
 from code_review_bot.report.mail_builderrors import BuildErrorsReporter
 from code_review_bot.report.phabricator import PhabricatorReporter
@@ -18,6 +19,7 @@ def get_reporters(configuration):
     """
     assert isinstance(configuration, list)
     reporters = {
+        "lando": LandoReporter,
         "mail": MailReporter,
         "build_error": BuildErrorsReporter,
         "phabricator": PhabricatorReporter,

--- a/bot/code_review_bot/report/lando.py
+++ b/bot/code_review_bot/report/lando.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import structlog
+
+from code_review_bot import Level
+from code_review_bot.report.base import Reporter
+
+logger = structlog.get_logger(__name__)
+
+LANDO_MESSAGE = "The code review bot found {errors} {errors_noun} which should be fixed to avoid backout and {warnings} {warnings_noun}."
+
+
+class LandoReporter(Reporter):
+    """
+    Update lando with a warning message
+    """
+
+    def __init__(self, configuration):
+        self.lando_api = None
+
+    def setup_api(self, lando_api):
+        logger.info("Publishing warnings to lando is enabled by the bot!")
+        self.lando_api = lando_api
+
+    def publish(self, issues, revision, task_failures, links):
+        """
+        Send an email to administrators
+        """
+        if self.lando_api is None:
+            logger.info("Lando integration is not set!")
+            return
+
+        nb_publishable = len([i for i in issues if i.is_publishable()])
+        nb_publishable_errors = sum(
+            1 for i in issues if i.is_publishable() and i.level == Level.Error
+        )
+
+        nb_publishable_warnings = nb_publishable - nb_publishable_errors
+
+        logger.info(
+            "Publishing warnings to lando for {0} errors and {1} warnings".format(
+                nb_publishable_errors, nb_publishable_warnings
+            ),
+            revision=revision.id,
+            diff=revision.diff["id"],
+        )
+
+        try:
+            # code-review.events sends an initial warning message to lando to specify that the analysis is in progress,
+            # we should remove it
+            self.lando_api.del_all_warnings(revision.id, revision.diff["id"])
+
+            if nb_publishable > 0:
+                self.lando_api.add_warning(
+                    LANDO_MESSAGE.format(
+                        errors=nb_publishable_errors,
+                        errors_noun="error" if nb_publishable_errors == 1 else "errors",
+                        warnings=nb_publishable_warnings,
+                        warnings_noun="warning"
+                        if nb_publishable_warnings == 1
+                        else "warnings",
+                    ),
+                    revision.id,
+                    revision.diff["id"],
+                )
+        except Exception as ex:
+            logger.error(str(ex))

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -1,5 +1,5 @@
 -e ../tools #egg=code-review-tools
 influxdb==5.3.1
-libmozdata==0.1.72
+libmozdata==0.1.73
 pyyaml==5.4.1
 rs-parsepatch==0.3.3

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -475,6 +475,7 @@ def mock_workflow(mock_config, mock_phabricator, mock_taskcluster_config):
     class MockWorkflow(Workflow):
         def __init__(self):
             self.reporters = {}
+            self.lando_api = None
             self.phabricator_api = None
             self.index_service = mock_taskcluster_config.get_service("index")
             self.queue_service = mock_taskcluster_config.get_service("queue")

--- a/bot/tests/test_reporter_lando.py
+++ b/bot/tests/test_reporter_lando.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from code_review_bot.report.lando import LANDO_MESSAGE
+from code_review_bot.report.lando import LandoReporter
+
+MOCK_LANDO_API_URL = "http://api.lando.test"
+MOCK_LANDO_TOKEN = "Some Test Token"
+
+
+class MockLandoWarnings(object):
+    """
+    LandoWarnings Mock class
+    """
+
+    def __init__(self, api_url, api_key):
+        self.api_url = MOCK_LANDO_API_URL
+        self.api_key = MOCK_LANDO_TOKEN
+
+    def del_warnings(self, warnings):
+        pass
+
+    def add_warning(self, warning, revision_id, diff_id):
+        self.revision_id = revision_id
+        self.diff_id = diff_id
+        self.warning = warning
+
+    def del_all_warnings(self, revision_id, diff_id):
+        self.revision_id = revision_id
+        self.diff_id = diff_id
+
+
+def test_lando(log, mock_clang_tidy_issues, mock_revision):
+    """
+    Test lando reporter
+    """
+
+    # empty config should be OK
+    assert LandoReporter({}).lando_api is None
+
+    r = LandoReporter({})
+
+    lando_api = MockLandoWarnings(api_url=MOCK_LANDO_API_URL, api_key=MOCK_LANDO_TOKEN)
+
+    r.setup_api(lando_api)
+
+    assert r.lando_api == lando_api
+
+    assert log.has("Publishing warnings to lando is enabled by the bot!")
+
+    r.publish(mock_clang_tidy_issues, mock_revision, [], [])
+
+    assert lando_api.revision_id == mock_revision.revision["id"]
+    assert lando_api.diff_id == mock_revision.diff_id
+    assert lando_api.warning == LANDO_MESSAGE.format(
+        errors=1, errors_noun="error", warnings=0, warnings_noun="warnings"
+    )
+
+    assert log.has("Publishing warnings to lando for 1 errors and 0 warnings")

--- a/events/requirements.txt
+++ b/events/requirements.txt
@@ -3,7 +3,7 @@ aioredis==2.0.0
 -e ../tools #egg=code-review-tools
 json-e==4.4.1
 jsonschema==3.2.0
-libmozdata==0.1.72
+libmozdata==0.1.73
 libmozevent==1.1.10
 python-hglib==2.6.2
 pytoml==0.1.21

--- a/events/tests/fixtures/phabricator/message-PHID-HMBT-icusvlfibcebizyd33op-fail-unit.json
+++ b/events/tests/fixtures/phabricator/message-PHID-HMBT-icusvlfibcebizyd33op-fail-unit.json
@@ -1,0 +1,3 @@
+{
+  "error_code": "error"
+}


### PR DESCRIPTION
With https://github.com/mozilla-conduit/lando-api/pull/172 we have support in lando to send warnings.
We are going to send two warnings for each diff for each revision:

- Once the revision has been updated/created an initial message will be send indicating the user that there are linters running:"Review time linters are still running. Are you sure you want to continue?"
- Just as the review bot finishes posting issues in phab we send the 2nd message with the issues or if there aren't any we clear previous send message.