### PR TITLE
bot: when no issues are detected still publish lando issues. Fixes #1003

### DIFF
--- a/bot/code_review_bot/report/mail.py
+++ b/bot/code_review_bot/report/mail.py
@@ -44,6 +44,10 @@ class MailReporter(Reporter):
         Send an email to administrators
         """
 
+        # For no issues do not publish anything
+        if len(issues) == 0:
+            return
+
         # Build stats display for all issues
         # One line per issues class
         stats = "\n".join(

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -100,9 +100,6 @@ class Workflow(object):
         )
         if not issues and not task_failures and not notices:
             logger.info("No issues or notices, stopping there.")
-            self.index(revision, state="done", issues=0)
-            self.update_status(revision, BuildState.Pass)
-            return []
 
         # Publish all issues
         self.publish(revision, issues, task_failures, notices)


### PR DESCRIPTION
The original issues comes from [here](https://github.com/mozilla/code-review/blob/59dc67cb99cd362d4bf21e12495319023de4175d/bot/code_review_bot/workflow.py#L104). This patch fixes this with a "not so nice" workaround because we don't want to have lando instance passed directly to the workflow.