### PR TITLE
bot: make sure we are sending utf-8 when publishing improvement patches.

### DIFF
--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -61,7 +61,7 @@ class ImprovementPatch(object):
         ), "Only publish on online Taskcluster tasks"
         self.url = taskcluster.upload_artifact(
             "public/patch/{}".format(self.name),
-            self.content,
+            str(self.content, "utf-8"),
             content_type="text/plain; charset=utf-8",  # Displays instead of download
             ttl=timedelta(days=days_ttl - 1),
         )


### PR DESCRIPTION
This should fixes issues like [this](https://phabricator.services.mozilla.com/D132030).