### PR TITLE
bot: publish artitact as `bytes` instead of `string`.

### DIFF
--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -61,7 +61,7 @@ class ImprovementPatch(object):
         ), "Only publish on online Taskcluster tasks"
         self.url = taskcluster.upload_artifact(
             "public/patch/{}".format(self.name),
-            self.content,
+            self.content.encode(),
             content_type="text/plain; charset=utf-8",  # Displays instead of download
             ttl=timedelta(days=days_ttl - 1),
         )

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -8,6 +8,6 @@ multidict==5.2.0
 raven==6.10.0
 rs_parsepatch==0.3.3
 structlog==21.2.0
-taskcluster==44.2.2
+taskcluster==44.4.0
 treeherder-client==5.0.0
 yarl==1.6.3


### PR DESCRIPTION
This must be merged in master after taskcluster is released, version greater than 44.2.2