### PR TITLE
events: all_tasks is now part of asyncio

### DIFF
--- a/events/code_review_events/workflow.py
+++ b/events/code_review_events/workflow.py
@@ -561,7 +561,7 @@ class Events(object):
             asyncio.get_event_loop().run_forever()
 
         # Make sure any pending task is run.
-        run_tasks(asyncio.Task.all_tasks())
+        run_tasks(asyncio.all_tasks())
 
         # Stop the webserver when other async processes are stopped
         if self.webserver:


### PR DESCRIPTION
Running the events loop causes this error:
```
[ERROR   ] libmozevent.utils: Failure while running async tasks (error="Error while reading from ec2-34-193-21-24.compute-1.amazonaws.com:30059 : (104, 'Connection reset by peer')")

Traceback (most recent call last):

  File "/usr/local/bin/code-review-events", line 33, in <module>

    sys.exit(load_entry_point('code-review-events==1.4.6', 'console_scripts', 'code-review-events')())

  File "/usr/local/lib/python3.9/site-packages/code_review_events-1.4.6-py3.9.egg/code_review_events/cli.py", line 78, in main

    events.run()

  File "/usr/local/lib/python3.9/site-packages/code_review_events-1.4.6-py3.9.egg/code_review_events/workflow.py", line 564, in run

    run_tasks(asyncio.Task.all_tasks())

AttributeError: type object '_asyncio.Task' has no attribute 'all_tasks'
```