### PR TITLE
Cast creation date as timestamptz to build issues checks stats

### DIFF
--- a/backend/code_review_backend/issues/api.py
+++ b/backend/code_review_backend/issues/api.py
@@ -7,6 +7,7 @@ from datetime import date
 from datetime import datetime
 from datetime import timedelta
 
+from django.conf import settings
 from django.db.models import Count
 from django.db.models import Q
 from django.db.models.functions import TruncDate
@@ -295,15 +296,19 @@ class IssueCheckHistory(CachedView, generics.ListAPIView):
                 since = datetime.strptime(since, "%Y-%m-%d")
             except ValueError:
                 raise APIException(detail="invalid since date - should be YYYY-MM-DD")
-            # Use a specific WHERE clause to compare the creation date.
-            # Casting the date as its natural data type (timestamptz) allow Postgres to perform an
-            # index scan on small data ranges (depending on available memory), which is much faster.
-            # Overall performance is improved in practice, even if the planned cost is higher when
-            # aggregating on the whole table.
-            since = since.strftime("%Y-%m-%d")
-            queryset = queryset.extra(
-                where=[f"created::timestamptz >= '{since}'::timestamptz"]
-            )
+
+            if "postgresql" in settings.DATABASES["default"]["ENGINE"]:
+                # Use a specific WHERE clause to compare the creation date.
+                # Casting the date as its natural data type (timestamptz) allow Postgres to perform an
+                # index scan on small data ranges (depending on available memory), which is much faster.
+                # Overall performance is improved in practice, even if the planned cost is higher when
+                # aggregating on the whole table.
+                since_date = since.strftime("%Y-%m-%d")
+                queryset = queryset.extra(
+                    where=[f"created::timestamptz >= '{since_date}'::timestamptz"]
+                )
+            else:
+                queryset = queryset.filter(date__gte=since.date())
 
         return queryset.order_by("date")
 


### PR DESCRIPTION
Ref. #1044

Improves overall performance on the endpoint, especially on small data ranges (blue line is this PR, red line is master) :
![pg_idx_seq_scan](https://user-images.githubusercontent.com/45713745/177532869-29d8ce78-a01b-401b-828a-4bb6b56ec18d.png)

A Vacuum can probably be performed on the database too, I got acceptable times on my setup with a production dump (<10s).