### PR TITLE
Bug 1610715 - Add a hint when error comes from a parent revision

### DIFF
--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -248,7 +248,9 @@ class PhabricatorReporter(Reporter):
 
         # Add extra hint when errors are published outside of the patch
         defects_details = ""
-        external_failures_count = sum(
+        # Only display the hint when the revision has parents in his stack
+        rev_parents_count = len(self.api.load_parents(revision.phid))
+        external_failures_count = rev_parents_count and sum(
             1
             for issue in issues
             if issue.is_publishable() and not revision.contains(issue)

--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -248,13 +248,15 @@ class PhabricatorReporter(Reporter):
 
         # Add extra hint when errors are published outside of the patch
         defects_details = ""
-        if any(
-            issue.is_publishable() and not revision.contains(issue) for issue in issues
-        ):
-            if nb == 1:
-                defects_details = " (in a parent revision)"
-            else:
-                defects_details = " (some in a parent revision)"
+        external_failures_count = sum(
+            1
+            for issue in issues
+            if issue.is_publishable() and not revision.contains(issue)
+        )
+        if nb == 1 and external_failures_count == 1:
+            defects_details = " (in a parent revision)"
+        elif nb > 1 and external_failures_count > 0:
+            defects_details = f" ({external_failures_count} in a parent revision)"
 
         if nb > 0:
             comment = COMMENT_FAILURE.format(

--- a/bot/tests/mocks/phabricator_edge_search.json
+++ b/bot/tests/mocks/phabricator_edge_search.json
@@ -1,6 +1,8 @@
 {
     "result": {
         "data": [
+          {"destinationPHID": 1},
+          {"destinationPHID": 2}
         ],
         "maps": {},
         "query": {

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -44,7 +44,7 @@ You can view these defects in the Diff Detail section of [Phabricator diff 42](h
 """
 
 VALID_BUILD_ERROR_MESSAGE = """
-Code analysis found 1 defect in the diff [42](https://phabricator.services.mozilla.com/differential/diff/42/):
+Code analysis found 1 defect (in a parent revision) in the diff [42](https://phabricator.services.mozilla.com/differential/diff/42/):
  - 1 build error found by clang-tidy
 
 IMPORTANT: Found 1 issue (error level) that must be fixed before landing.
@@ -132,7 +132,7 @@ If you see a problem in this automated review, [please report it here](https://b
 """
 
 VALID_MOZLINT_MESSAGE = """
-Code analysis found 2 defects in the diff [42](https://phabricator.services.mozilla.com/differential/diff/42/):
+Code analysis found 2 defects (some in a parent revision) in the diff [42](https://phabricator.services.mozilla.com/differential/diff/42/):
  - 2 defects found by dummy (Mozlint)
 
 WARNING: Found 1 issue (warning level) that can be dismissed.

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -132,7 +132,7 @@ If you see a problem in this automated review, [please report it here](https://b
 """
 
 VALID_MOZLINT_MESSAGE = """
-Code analysis found 2 defects (some in a parent revision) in the diff [42](https://phabricator.services.mozilla.com/differential/diff/42/):
+Code analysis found 2 defects (1 in a parent revision) in the diff [42](https://phabricator.services.mozilla.com/differential/diff/42/):
  - 2 defects found by dummy (Mozlint)
 
 WARNING: Found 1 issue (warning level) that can be dismissed.


### PR DESCRIPTION
Follow-up of #561 and #690
Closes #553