### PR TITLE
Use sentry_sdk instead of raven and improve Sentry grouping

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,6 @@
 [settings]
 known_first_party = code_review_backend,code_review_bot,code_review_tools,code_review_events,conftest
-known_third_party = dj_database_url,django,drf_yasg,influxdb,jsone,jsonschema,libmozdata,libmozevent,logbook,parsepatch,pytest,raven,requests,responses,rest_framework,rs_parsepatch,sentry_sdk,setuptools,structlog,taskcluster,yaml
+known_third_party = dj_database_url,django,drf_yasg,influxdb,jsone,jsonschema,libmozdata,libmozevent,parsepatch,pkg_resources,pytest,requests,responses,rest_framework,rs_parsepatch,sentry_sdk,setuptools,structlog,taskcluster,yaml
 force_single_line = True
 default_section=FIRSTPARTY
 line_length=159

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,5 @@ djangorestframework==3.13.1
 drf-yasg==1.21.3
 gunicorn==20.1.0
 psycopg2-binary==2.9.3
-sentry-sdk==1.7.2
 sqlparse==0.4.2
 whitenoise==6.2.0

--- a/tools/code_review_tools/log.py
+++ b/tools/code_review_tools/log.py
@@ -3,29 +3,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import logging
+import logging.handlers
 import os
+import sys
 
-import logbook
-import logbook.more
-import raven
-import raven.handlers.logbook
+import pkg_resources
+import sentry_sdk
 import structlog
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+root = logging.getLogger()
 
 
-class UnstructuredRenderer(structlog.processors.KeyValueRenderer):
-    def __call__(self, logger, method_name, event_dict):
-        event = None
-        if "event" in event_dict:
-            event = event_dict.pop("event")
-        if event_dict or event is None:
-            # if there are other keys, use the parent class to render them
-            # and append to the event
-            rendered = super(UnstructuredRenderer, self).__call__(
-                logger, method_name, event_dict
-            )
-            return f"{event} ({rendered})"
-        else:
-            return event
+class AppNameFilter(logging.Filter):
+    def __init__(self, project_name, channel, *args, **kwargs):
+        self.project_name = project_name
+        self.channel = channel
+        super().__init__(*args, **kwargs)
+
+    def filter(self, record):
+        record.app_name = f"code-review/{self.channel}/{self.project_name}"
+        return True
 
 
 def setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT):
@@ -34,14 +33,17 @@ def setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT):
     """
 
     # Setup papertrail
-    papertrail = logbook.SyslogHandler(
-        application_name=f"code-review/{channel}/{project_name}",
+    papertrail = logging.handlers.SysLogHandler(
         address=(PAPERTRAIL_HOST, int(PAPERTRAIL_PORT)),
-        level=logbook.INFO,
-        format_string="{record.time} {record.channel}: {record.message}",
-        bubble=True,
     )
-    papertrail.push_application()
+    formatter = logging.Formatter(
+        "%(app_name)s: %(asctime)s %(filename)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    papertrail.setLevel(logging.INFO)
+    papertrail.setFormatter(formatter)
+    papertrail.addFilter(AppNameFilter(project_name, channel))
+    root.addHandler(papertrail)
 
 
 def setup_sentry(name, channel, dsn):
@@ -58,29 +60,29 @@ def setup_sentry(name, channel, dsn):
     else:
         site = "unknown"
 
-    sentry_client = raven.Client(
-        dsn=dsn,
-        site=site,
-        name=name,
-        environment=channel,
-        release=raven.fetch_package_version(f"code-review-{name}"),
+    sentry_logging = LoggingIntegration(
+        level=logging.INFO,  # Capture info and above as breadcrumbs
+        event_level=logging.WARNING,  # Send warnings as events
     )
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[sentry_logging],
+        server_name=name,
+        environment=channel,
+        release=pkg_resources.get_distribution(f"code-review-{name}").version,
+    )
+    sentry_sdk.set_tag("site", site)
 
     if task_id is not None:
         # Add a Taskcluster task id when available
         # It will be shown in the Additional Data section on the dashboard
-        sentry_client.context.merge({"extra": {"task_id": task_id}})
-
-    sentry_handler = raven.handlers.logbook.SentryHandler(
-        sentry_client, level=logbook.WARNING, bubble=True
-    )
-    sentry_handler.push_application()
+        sentry_sdk.set_context("task", {"task_id": task_id})
 
 
 def init_logger(
     project_name,
     channel=None,
-    level=logbook.INFO,
+    level=logging.INFO,
     PAPERTRAIL_HOST=None,
     PAPERTRAIL_PORT=None,
     SENTRY_DSN=None,
@@ -89,36 +91,33 @@ def init_logger(
     if not channel:
         channel = os.environ.get("APP_CHANNEL")
 
-    # Output logs on stderr, with color support on consoles
-    fmt = "{record.time} [{record.level_name:<8}] {record.channel}: {record.message}"
-    handler = logbook.more.ColorizedStderrHandler(level=level, format_string=fmt)
-    handler.push_application()
+    logging.basicConfig(
+        format="%(asctime)s.%(msecs)06d [%(levelname)-8s] %(filename)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        stream=sys.stdout,
+        level=level,
+    )
 
     # Log to papertrail
     if channel and PAPERTRAIL_HOST and PAPERTRAIL_PORT:
         setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT)
 
-    # Log to senty
+    # Log to sentry
     if channel and SENTRY_DSN:
         setup_sentry(project_name, channel, SENTRY_DSN)
 
-    def logbook_factory(*args, **kwargs):
-        # Logger given to structlog
-        logbook.compat.redirect_logging()
-        return logbook.Logger(level=level, *args, **kwargs)
-
-    # Setup structlog over logbook, with args list at the end
+    # Setup structlog
     processors = [
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.StackInfoRenderer(),
         structlog.processors.format_exc_info,
-        UnstructuredRenderer(),
+        structlog.stdlib.render_to_log_kwargs,
     ]
 
     structlog.configure(
-        context_class=structlog.threadlocal.wrap_dict(dict),
         processors=processors,
-        logger_factory=logbook_factory,
+        context_class=structlog.threadlocal.wrap_dict(dict),
+        logger_factory=structlog.stdlib.LoggerFactory(),
         wrapper_class=structlog.stdlib.BoundLogger,
         cache_logger_on_first_use=True,
     )

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,10 +3,9 @@ async-timeout==4.0.2
 
 # Limit idna to avid conflicts
 idna>=2.5,<3.4
-logbook==1.5.3
 multidict==6.0.2
-raven==6.10.0
 rs_parsepatch==0.3.7
+sentry_sdk==1.9.0
 structlog==22.1.0
 taskcluster==44.17.2
 treeherder-client==5.0.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,7 +5,7 @@ async-timeout==4.0.2
 idna>=2.5,<3.4
 multidict==6.0.2
 rs_parsepatch==0.3.7
-sentry_sdk==1.9.0
+sentry-sdk==1.9.0
 structlog==22.1.0
 taskcluster==44.17.2
 treeherder-client==5.0.0


### PR DESCRIPTION
Closes #1225 

Please test carefully this PR, I am not really familiar with **Sentry** and **Papertrail** and may have missed some details that may no longer appear in the logs or in Sentry issues and are very crucial for you. As you will see in the following screenshots, I was able to test the **Sentry** integration using a real instance. Regarding **Papertrail**, I simply redirected the output to `/dev/log`, rather than to a real Papertrail instance using a `host` and a `port`, so that I could check the format of the logs but that's all.

## The issue

As stated in issue #1225, the concern encountered is that the Sentry issue name almost always includes a unique context which prevents issues from being grouped together by having several different events attached.

**Currently we have:**
Issue number 1 (`context_element=1`) => 1 attached event
Issue number 1 (`context_element=2`) => 1 attached event
Issue number 2 (`other_context_element=1`) => 1 attached event

**The requested modifications would allow us to obtain the following grouping:**
Issue number 1 => 2 attached events, event 1 (`context_element=1`) & event 2 (`context_element=2`)
Issue number 2 => 1 attached event

## The illustrated results

See the following screenshots with test data that illustrate the new grouping.

**Before:**
_Two issues with one attached event_
![Two issues with one attached event](https://user-images.githubusercontent.com/19348323/182569721-30c7bd81-b5c7-41fb-8a31-794c49118ec8.png)

**After:**
_One issue with two attached events_
![One issue with two attached events](https://user-images.githubusercontent.com/19348323/182569787-136c2329-bc95-4eeb-9dfe-978cb8a89d65.png)

_Additional Data section for the first event_
![Additional Data section for the first event](https://user-images.githubusercontent.com/19348323/182569800-1ee80ac9-6e78-4869-967c-17b818991e89.png)

## The implementation

I made a mix of the two solutions suggested by Bastien in [this comment](https://github.com/mozilla/code-review/issues/1225#issuecomment-1202164904), meaning, I kept `structlog` to avoid having to modify a lot of lines and also having to submit a PR on `libmozevent` and I didn't add the new dependency called `structlog_sentry` that we mentioned.

Each log follows a specific path:
1. The log is created by using a `logger.info`, `logger.warning`, etc, knowing that the logger is the `structlog` one.
2. It passes through several `structlog` processors as before, except that a new processor can also transpose the remaining attributes of the `event_dict` of this log into `extra` for `logging.log`.
3. 
      - The log is outputted on `stdout` using a custom format (I tried to reproduce the same structure as the one from `logbook`, minus the colorization)
      - If **Papertrail** is activated, a handler of type `SysLogHandler` is in charge of transmitting the log using another custom format
      - If **Sentry** is activated, thanks to the logging integration of `sentry_sdk`, the log is captured and sent back to Sentry. `sentry_sdk` will take care of getting the `extra` attribute of the log to translate it into **Additional Data** to be added on each event.

The problem with the previous implementation was that [one of the processors](https://github.com/mozilla/code-review/blob/master/tools/code_review_tools/log.py#L15) was adding the context in the title of each issue rather than serving it as **Additional Data** as it does now.

I was able to replace the `raven` dependency with the `sentry_sdk` one and drop the use of `logbook` completely.