### PR TITLE
Update libmozevent dependency to 1.1.14

### DIFF
--- a/events/requirements.txt
+++ b/events/requirements.txt
@@ -4,7 +4,7 @@ aioredis==2.0.1
 json-e==4.4.3
 jsonschema==4.9.1
 libmozdata==0.1.79
-libmozevent==1.1.13
+libmozevent==1.1.14
 python-hglib==2.6.2
 pytoml==0.1.21
 pyyaml==6.0


### PR DESCRIPTION
Refs. #135

This should fix errors when pushing builds to try