### PR TITLE
bot: add force publish field

### DIFF
--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -436,6 +436,8 @@ class Workflow(object):
             return ExternalTidyTask(task_id, task_status)
         elif name == "source-test-taskgraph-diff":
             return TaskGraphDiffTask(task_id, task_status)
+        elif name.startsWith("source-test-shadow-scheduler"):
+            return None
         elif settings.autoland_group_id is not None and not name.startswith(
             "source-test-"
         ):


### PR DESCRIPTION
Some checks, like some clang-tidy specific ones, they do not assert errors an the places where they assert the warnings are not part of the patch. These checks are for code quality improvement over time and the developer should still need to see a warning maybe he wants to contribute. 
This is why we use this extra field.