### PR TITLE
Move flake8 from gitlab to github.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
Since flake8 move away from gitlab to github we should do the same otherwise our infra will be remain buster. Same thing we did for mozilla/libmozevent