### PR TITLE
Output more precise Phabricator comments in DocUploadTask

### DIFF
--- a/bot/code_review_bot/tasks/docupload.py
+++ b/bot/code_review_bot/tasks/docupload.py
@@ -1,15 +1,40 @@
 # -*- coding: utf-8 -*-
+import os
+
 import structlog
 
 from code_review_bot.tasks.base import NoticeTask
 
 logger = structlog.get_logger(__name__)
 
-COMMENT_LINK_TO_DOC = """
-NOTE: Documentation was modified in diff {diff_id}
+MAX_LINKS = 20
 
-It can be previewed [here]({doc_url}) for one week.
+DOC_LINK = """
+- file [{path}]({doc_url})
 """
+COMMENT_LINKS_TO_DOC = """
+NOTE: {nb_docs_hint} modified in diff {diff_id}
+
+{pronoun} can be previewed for one week: {doc_urls}
+"""
+
+COMMENT_LINK_TO_DOC = """
+NOTE: Several documentation files were modified in diff {diff_id}
+
+They can be previewed [here]({doc_url}) for one week.
+"""
+
+
+def precise_doc_url(path, doc_url, trees):
+    root_doc_url = os.path.dirname(doc_url)
+    filename, _ = os.path.splitext(os.path.basename(path))
+    dir = os.path.dirname(path)
+    for doc_path, dir_path in trees.items():
+        if dir == dir_path:
+            # Forging the link towards the documentation
+            return f"{root_doc_url}/{doc_path}/{filename}.html"
+    # We didn't find a mapping for the file in the trees artifact
+    return doc_url
 
 
 class DocUploadTask(NoticeTask):
@@ -17,7 +42,7 @@ class DocUploadTask(NoticeTask):
     Support doc-upload tasks
     """
 
-    artifacts = ["public/firefox-source-docs-url.txt"]
+    artifacts = ["public/firefox-source-docs-url.txt", "public/trees.json"]
 
     @property
     def display_name(self):
@@ -30,4 +55,33 @@ class DocUploadTask(NoticeTask):
             return ""
 
         doc_url = artifact.decode("utf-8")
-        return COMMENT_LINK_TO_DOC.format(diff_id=revision.diff_id, doc_url=doc_url)
+
+        trees = artifacts.get("public/trees.json")
+        if trees is None:
+            logger.warn("Missing trees.json")
+
+        doc_files = [file for file in revision.files if "docs" in file]
+        nb_docs = len(doc_files)
+        if not trees or nb_docs > MAX_LINKS:
+            return COMMENT_LINK_TO_DOC.format(diff_id=revision.diff_id, doc_url=doc_url)
+
+        nb_docs_hint = (
+            f"{nb_docs} documentation files were"
+            if nb_docs > 1
+            else f"{nb_docs} documentation file was"
+        )
+        pronoun = "They" if nb_docs > 1 else "It"
+        doc_urls = "".join(
+            [
+                DOC_LINK.format(
+                    path=file, doc_url=precise_doc_url(file, doc_url, trees)
+                )
+                for file in doc_files
+            ]
+        )
+        return COMMENT_LINKS_TO_DOC.format(
+            nb_docs_hint=nb_docs_hint,
+            diff_id=revision.diff_id,
+            pronoun=pronoun,
+            doc_urls=doc_urls,
+        )


### PR DESCRIPTION
Closes #1413

The logic is:
- **IF** we fail to retrieve the mapping (`trees.json` artifact) **OR** if we have more than `MAX_LINKS` documentation files updated within the revision, then we will output the previous comment, the one only containing a link towards the root of the documentation, to avoid sending very long outputs to Phabricator.
- **ELSE**, we will output a comment containing a list of precise links with as many as there are updated documentation files. The "precise" links are forged as follows:
  - **If** the `dirname` of the `file` doesn't exist in the mapping, we use the root of the documentation by default
  - **Else** we retrieve the `dirname` of the documentation root + the match we found in the mapping  + the `name` of the `file` (without its extension)  + `.html`.
  
I'm not a hundred percent sure the forging of the "precise" links matches what we were expecting, please tell me if I need to adjust anything.

Here are some comments I was able to generate while testing my work:
#### Only 1 documentation file updated
##### Files
```
revision.files = [
    "some/other/file.txt",  # not a documentation file
    "devtools/docs/contributor/test.md",  # matched
]
```

##### Comment
![Capture d’écran du 2022-11-23 17-00-30](https://user-images.githubusercontent.com/19348323/203592591-5e7c28d0-319b-4283-a082-6a93f2774ddf.png)


#### Various documentation files updated
##### Files
```
revision.files = [
    "some/other/file.txt",  # not a documentation file
    "docs/whatever/test.md",  # not in the trees mapping
    "docs/code-quality/coding_style_cpp.rst",  # matched
    "accessible/docs/test.md",  # matched
    "devtools/docs/contributor/test.md",  # matched
]
```

##### Comment
![Capture d’écran du 2022-11-23 16-59-17](https://user-images.githubusercontent.com/19348323/203592571-7e84e7e5-4e95-432f-b352-b67edb8ec311.png)


#### More than 20 documentation files updated
##### Files
```
revision.files = [
    "some/other/file.txt",  # not a documentation file
    "docs/whatever/test.md",  # not in the trees mapping
] + [
    "devtools/docs/contributor/test.md",  # matched
] * 20
```

##### Comment
![Capture d’écran du 2022-11-23 16-59-04](https://user-images.githubusercontent.com/19348323/203592536-b577b729-4b45-4ebf-a5d7-ed38b0d33f09.png)