### PR TITLE
Bug 1805148 - Detect documentation files using trees.json prefixes in DocUploadTask

### DIFF
--- a/bot/code_review_bot/tasks/docupload.py
+++ b/bot/code_review_bot/tasks/docupload.py
@@ -78,11 +78,16 @@ class DocUploadTask(NoticeTask):
         trees = artifacts.get("public/trees.json")
         if trees is None:
             logger.warn("Missing trees.json")
+            # The mapping is now mandatory to detect documentation changes
+            return ""
 
         doc_files = [
             file
             for file in revision.files
-            if "docs" in file and file.endswith(DOC_FILE_SUFFIXES)
+            if any(
+                os.path.dirname(file).startswith(prefix) for prefix in trees.values()
+            )
+            and file.endswith(DOC_FILE_SUFFIXES)
         ]
         nb_docs = len(doc_files)
         if not nb_docs:
@@ -91,7 +96,7 @@ class DocUploadTask(NoticeTask):
             )
             return ""
 
-        if not trees or nb_docs > MAX_LINKS:
+        if nb_docs > MAX_LINKS:
             return COMMENT_LINK_TO_DOC.format(diff_id=revision.diff_id, doc_url=doc_url)
 
         nb_docs_hint = (

--- a/bot/tests/test_docupload_task.py
+++ b/bot/tests/test_docupload_task.py
@@ -27,7 +27,7 @@ It can be previewed for one week:
 """
 
 VARIOUS_DIRECT_LINKS = """
-NOTE: 4 documentation files were modified in diff 42
+NOTE: 3 documentation files were modified in diff 42
 
 They can be previewed for one week:
 - file [docs/folderA/index.rst](http://firefox-test-docs.mozilla.org/section1/index.html)
@@ -35,8 +35,6 @@ They can be previewed for one week:
 - file [docs/folderB/folderC/index.rst](http://firefox-test-docs.mozilla.org/section2/index.html)
 
 - file [docs/folderB/folderC/subfolder/index.md](http://firefox-test-docs.mozilla.org/section2/subfolder/index.html)
-
-- file [docs/folderD/index.rst](http://firefox-test-docs.mozilla.org/index.html)
 
 """
 
@@ -69,7 +67,7 @@ def test_build_notice_no_trees_artifact(mock_revision, mock_doc_upload_task):
 
     mock_revision.files = ["file1.txt", "docs/folderA/index.rst"]
     notice = mock_doc_upload_task.build_notice(artifacts, mock_revision)
-    assert notice == MISSING_MAPPING_OR_MORE_THAN_TWENTY
+    assert notice == ""
 
 
 def test_build_notice_no_documentation_file(mock_revision, mock_doc_upload_task):
@@ -93,12 +91,12 @@ def test_build_notice_only_one_file(mock_revision, mock_doc_upload_task):
 
 def test_build_notice_various_files(mock_revision, mock_doc_upload_task):
     mock_revision.files = [
-        "file1.txt",  # not a documentation file
-        "docs/image.svg",  # not a documentation file
+        "file1.txt",  # not a documentation file (bad prefix and bad extension)
+        "docs/folderA/image.svg",  # not a documentation file (bad extension)
         "docs/folderA/index.rst",  # complete match on "folderA"
         "docs/folderB/folderC/index.rst",  # complete match on "folderB/folderC"
         "docs/folderB/folderC/subfolder/index.md",  # partial match on a prefix "folderB/folderC"
-        "docs/folderD/index.rst",  # no match
+        "docs/folderD/index.rst",  # not a documentation file (bad prefix)
     ]
     notice = mock_doc_upload_task.build_notice(ARTIFACTS, mock_revision)
     assert notice == VARIOUS_DIRECT_LINKS


### PR DESCRIPTION
Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1805148

I was able to generate the following comment for the reported Diff:
```
NOTE: 4 documentation files were modified in diff 658067

They can be previewed for one week:
- file [remote/doc/messagehandler/index.rst](http://gecko-docs.mozilla.org-l1.s3-website.us-west-2.amazonaws.com/main/59702088-79fc-11ed-8cc7-0242ac110004/remote/messagehandler/index.html)

- file [remote/doc/messagehandler/SimpleExample.md](http://gecko-docs.mozilla.org-l1.s3-website.us-west-2.amazonaws.com/main/59702088-79fc-11ed-8cc7-0242ac110004/remote/messagehandler/SimpleExample.html)

- file [remote/doc/messagehandler/Intro.md](http://gecko-docs.mozilla.org-l1.s3-website.us-west-2.amazonaws.com/main/59702088-79fc-11ed-8cc7-0242ac110004/remote/messagehandler/Intro.html)

- file [remote/doc/index.rst](http://gecko-docs.mozilla.org-l1.s3-website.us-west-2.amazonaws.com/main/59702088-79fc-11ed-8cc7-0242ac110004/remote/index.html)
```