### PR TITLE
Speedup issues list in admin interface

### DIFF
--- a/backend/code_review_backend/issues/admin.py
+++ b/backend/code_review_backend/issues/admin.py
@@ -29,8 +29,7 @@ class RevisionAdmin(admin.ModelAdmin):
 
 class IssueAdmin(admin.ModelAdmin):
     list_filter = ("analyzer",)
-    list_display = ("id", "path", "line", "level", "analyzer", "analyzer_check", "diff")
-    list_select_related = ("diff",)
+    list_display = ("id", "path", "line", "level", "analyzer", "analyzer_check")
 
 
 admin.site.register(Repository, RepositoryAdmin)

--- a/backend/code_review_backend/issues/admin.py
+++ b/backend/code_review_backend/issues/admin.py
@@ -29,7 +29,18 @@ class RevisionAdmin(admin.ModelAdmin):
 
 class IssueAdmin(admin.ModelAdmin):
     list_filter = ("analyzer",)
-    list_display = ("id", "path", "line", "level", "analyzer", "analyzer_check")
+    list_display = (
+        "id",
+        "path",
+        "line",
+        "level",
+        "analyzer",
+        "analyzer_check",
+        "created",
+        "diff_id",
+    )
+    search_fields = ("line", "analyzer", "path")
+    ordering = ("-created",)
 
 
 admin.site.register(Repository, RepositoryAdmin)

--- a/backend/code_review_backend/issues/models.py
+++ b/backend/code_review_backend/issues/models.py
@@ -112,7 +112,7 @@ class Issue(models.Model):
     updated = models.DateTimeField(auto_now=True)
 
     class Meta:
-        ordering = ("diff", "path", "line", "analyzer")
+        ordering = ("diff_id", "path", "line", "analyzer")
 
     @property
     def publishable(self):


### PR DESCRIPTION
- Do not load associated diffs, just to sort by Diff ID
- Sort by creation date (most recent first)
- Keep analyzer filtering as is, but this is now the heaviest query on the page