### PR TITLE
In `build_tak` for tasks that do not match anything returrn None.

### DIFF
--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -442,7 +442,7 @@ class Workflow(object):
             # Log cleanly on autoland unknown tasks
             logger.info("Skipping unknown task", id=task_id, name=name)
         else:
-            return DefaultTask(task_id, task_status)
+            return None
 
     def update_status(self, revision, state):
         """

--- a/bot/tests/test_remote.py
+++ b/bot/tests/test_remote.py
@@ -351,7 +351,7 @@ def test_unsupported_analyzer(mock_config, mock_revision, mock_workflow, mock_ba
     )
     issues = mock_workflow.run(mock_revision)
     assert len(issues) == 0
-    assert mock_revision._state == BuildState.Fail
+    assert mock_revision._state == BuildState.Pass
 
 
 def test_decision_task(mock_config, mock_revision, mock_workflow, mock_backend):

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -13,7 +13,6 @@ from code_review_bot.revisions import Revision
 from code_review_bot.tasks.clang_format import ClangFormatTask
 from code_review_bot.tasks.clang_tidy import ClangTidyTask
 from code_review_bot.tasks.clang_tidy_external import ExternalTidyTask
-from code_review_bot.tasks.default import DefaultTask
 from code_review_bot.tasks.lint import MozLintTask
 from code_review_bot.tasks.tgdiff import TaskGraphDiffTask
 
@@ -97,11 +96,8 @@ def test_taskcluster_index(mock_config, mock_workflow, mock_try_task):
         ("source-test-clang-format", ClangFormatTask, True),
         ("source-test-taskgraph-diff", TaskGraphDiffTask, False),
         ("source-test-taskgraph-diff", TaskGraphDiffTask, True),
-        ("source-test-unsupported", DefaultTask, False),
-        ("source-test-unsupported", DefaultTask, True),
-        # On autoland, we only support source-test tasks
-        ("totally-unknown", DefaultTask, False),
-        ("totally-unknown", None, True),
+        ("source-test-unsupported", None, False),
+        ("source-test-unsupported", None, True),
     ],
 )
 def test_build_task(task_name, result, on_autoland, mock_config, mock_workflow):


### PR DESCRIPTION
This type of tasks doesn't expose issues.json so we should ignore it.