### PR TITLE
bot: do not log warning when we don't report anything on a per line basis.

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -86,7 +86,7 @@ class Issue(abc.ABC):
         self.line = positive_int("line", line)
         self.nb_lines = positive_int("nb_lines", nb_lines)
 
-        # Support line 0, with a Sentry warning
+        # Support line 0 for full file issues like `source-test-mozlint-test-manifest`.
         if self.line == 0:
             logger.info("Line 0 is not supported, falling back to full file issue")
             self.line = None


### PR DESCRIPTION
This will resolve warnings like: https://mozilla.sentry.io/issues/3532261274/?alert_rule_id=12607839&alert_timestamp=1677568283919&alert_type=email&environment=production&project=6273985 that are not actionable and the linter still runs without issues.