### PR TITLE
Filter by date revision on the target repository listing issues

### DIFF
--- a/backend/code_review_backend/issues/api.py
+++ b/backend/code_review_backend/issues/api.py
@@ -378,6 +378,7 @@ class IssueList(generics.ListAPIView):
                 # Look for a revision matching this date, going back to 2 days maximum
                 date_revision = (
                     Revision.objects.filter(
+                        repository=repo,
                         created__gte=date - timedelta(2),
                         created__lt=date,
                     )


### PR DESCRIPTION
Follow up of #1425

Otherwise the most recent revision may be from any other repository from the required one, resulting in an empty queryset (ie. `qs.filter(revisions__id=<recent_rev>, revisions__repository__slug=<other_repo>)`).