### PR TITLE
Add #taskgraph-reviewers on the Phabricator revision following the output of the TGDiff task

### DIFF
--- a/bot/code_review_bot/report/debug.py
+++ b/bot/code_review_bot/report/debug.py
@@ -24,7 +24,7 @@ class DebugReporter(Reporter):
         assert os.path.isdir(output_dir), "Invalid output dir"
         self.report_path = os.path.join(output_dir, "report.json")
 
-    def publish(self, issues, revision, task_failures, links):
+    def publish(self, issues, revision, task_failures, links, reviewers):
         """
         Display issues choices
         """

--- a/bot/code_review_bot/report/lando.py
+++ b/bot/code_review_bot/report/lando.py
@@ -25,7 +25,7 @@ class LandoReporter(Reporter):
         logger.info("Publishing warnings to lando is enabled by the bot!")
         self.lando_api = lando_api
 
-    def publish(self, issues, revision, task_failures, links):
+    def publish(self, issues, revision, task_failures, links, reviewers):
         """
         Send an email to administrators
         """

--- a/bot/code_review_bot/report/mail.py
+++ b/bot/code_review_bot/report/mail.py
@@ -39,7 +39,7 @@ class MailReporter(Reporter):
 
         logger.info("Mail report enabled", emails=self.emails)
 
-    def publish(self, issues, revision, task_failures, links):
+    def publish(self, issues, revision, task_failures, links, reviewers):
         """
         Send an email to administrators
         """

--- a/bot/code_review_bot/report/mail_builderrors.py
+++ b/bot/code_review_bot/report/mail_builderrors.py
@@ -29,7 +29,7 @@ class BuildErrorsReporter(Reporter):
 
         logger.info("BuildErrorsReporter report enabled.")
 
-    def publish(self, issues, revision, task_failures, links):
+    def publish(self, issues, revision, task_failures, links, reviewers):
         """
         Send an email to the author of the revision
         """

--- a/bot/code_review_bot/tasks/tgdiff.py
+++ b/bot/code_review_bot/tasks/tgdiff.py
@@ -54,14 +54,16 @@ class TaskGraphDiffTask(NoticeTask):
             # Make sure we avoid using the proxy URL.
             queue_service.options["rootUrl"] = tc_config.default_url
             for a in queue_service.listArtifacts(self.id, self.run_id)["artifacts"]:
-                if a["name"].startswith("public/taskgraph/diffs/"):
-                    self.artifact_urls[a["name"]] = queue_service.buildUrl(
-                        "getArtifact", self.id, self.run_id, a["name"]
-                    )
-
                 if a["name"] == SUMMARY_ARTIFACT_PATH:
                     summary, _ = self.load_artifact(
                         queue_service, SUMMARY_ARTIFACT_PATH
+                    )
+                    # We don't want to add the summary.json to the artifact_urls list
+                    continue
+
+                if a["name"].startswith("public/taskgraph/diffs/"):
+                    self.artifact_urls[a["name"]] = queue_service.buildUrl(
+                        "getArtifact", self.id, self.run_id, a["name"]
                     )
 
         except Exception as e:

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -98,14 +98,14 @@ class Workflow(object):
         revision.analyze_patch()
 
         # Find issues on remote tasks
-        issues, task_failures, notices = self.find_issues(
+        issues, task_failures, notices, reviewers = self.find_issues(
             revision, settings.try_group_id
         )
         if not issues and not task_failures and not notices:
             logger.info("No issues or notices, stopping there.")
 
         # Publish all issues
-        self.publish(revision, issues, task_failures, notices)
+        self.publish(revision, issues, task_failures, notices, reviewers)
 
         return issues
 
@@ -187,7 +187,7 @@ class Workflow(object):
         else:
             logger.info("No issues for that revision")
 
-    def publish(self, revision, issues, task_failures, notices):
+    def publish(self, revision, issues, task_failures, notices, reviewers):
         """
         Publish issues on selected reporters
         """
@@ -223,7 +223,7 @@ class Workflow(object):
         # Publish reports about these issues
         with stats.timer("runtime.reports"):
             for reporter in self.reporters.values():
-                reporter.publish(issues, revision, task_failures, notices)
+                reporter.publish(issues, revision, task_failures, notices, reviewers)
 
         self.index(
             revision, state="done", issues=nb_issues, issues_publishable=nb_publishable
@@ -405,7 +405,7 @@ class Workflow(object):
                 )
                 raise
 
-        return issues, task_failures, notices
+        return issues, task_failures, notices, task.extra_reviewers_groups
 
     def build_task(self, task_status):
         """

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -20,6 +20,7 @@ from code_review_bot.config import settings
 from code_review_bot.report.debug import DebugReporter
 from code_review_bot.revisions import Revision
 from code_review_bot.tasks.base import AnalysisTask
+from code_review_bot.tasks.base import BaseTask
 from code_review_bot.tasks.base import NoticeTask
 from code_review_bot.tasks.clang_format import ClangFormatTask
 from code_review_bot.tasks.clang_tidy import ClangTidyTask
@@ -338,7 +339,7 @@ class Workflow(object):
             task = tasks[dependencies[0]]
             if task["task"]["metadata"]["name"] == "Gecko Decision Task":
                 logger.warn("Only dependency is a Decision Task, skipping analysis")
-                return [], [], []
+                return [], [], [], []
 
         # Add zero-coverage task
         if self.zero_coverage_enabled:
@@ -405,7 +406,10 @@ class Workflow(object):
                 )
                 raise
 
-        return issues, task_failures, notices, task.extra_reviewers_groups
+        reviewers = (
+            task.extra_reviewers_groups if task and isinstance(task, BaseTask) else []
+        )
+        return issues, task_failures, notices, reviewers
 
     def build_task(self, task_status):
         """

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -1,4 +1,4 @@
 -e ../tools #egg=code-review-tools
 influxdb==5.3.1
-libmozdata==0.1.85
+libmozdata==0.1.86
 pyyaml==6.0

--- a/bot/tests/test_reporter_debug.py
+++ b/bot/tests/test_reporter_debug.py
@@ -43,7 +43,7 @@ def test_publication(tmpdir, mock_issues, mock_revision):
     task = ClangTidyTask("someTaskId", status)
 
     r = DebugReporter(report_dir)
-    r.publish(mock_issues, mock_revision, [task], [])
+    r.publish(mock_issues, mock_revision, [task], [], [])
 
     assert os.path.exists(report_path)
     with open(report_path) as f:

--- a/bot/tests/test_reporter_lando.py
+++ b/bot/tests/test_reporter_lando.py
@@ -50,7 +50,7 @@ def test_lando(log, mock_clang_tidy_issues, mock_revision):
 
     assert log.has("Publishing warnings to lando is enabled by the bot!")
 
-    r.publish(mock_clang_tidy_issues, mock_revision, [], [])
+    r.publish(mock_clang_tidy_issues, mock_revision, [], [], [])
 
     assert lando_api.revision_id == mock_revision.revision["id"]
     assert lando_api.diff_id == mock_revision.diff_id

--- a/bot/tests/test_reporter_mail.py
+++ b/bot/tests/test_reporter_mail.py
@@ -120,7 +120,7 @@ def test_mail(
     list(
         map(lambda p: p.write(), mock_revision.improvement_patches)
     )  # trigger local write
-    r.publish(mock_issues, mock_revision, [], [])
+    r.publish(mock_issues, mock_revision, [], [], [])
 
     # Check stats
     assert r.calc_stats(mock_issues) == [
@@ -166,6 +166,6 @@ def test_mail_builderrors(
     conf = {"emails": ["test@mozilla.com"]}
     r = BuildErrorsReporter(conf)
 
-    r.publish(mock_clang_tidy_issues, mock_revision, [], [])
+    r.publish(mock_clang_tidy_issues, mock_revision, [], [], [])
 
     assert log.has("Send build error email", to="test@mozilla.com")

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -264,7 +264,7 @@ def test_phabricator_clang_tidy(mock_phabricator, phab, mock_try_task, mock_task
     )
     assert issue.is_publishable()
 
-    issues, patches = reporter.publish([issue], revision, [], [])
+    issues, patches = reporter.publish([issue], revision, [], [], [])
     assert len(issues) == 1
     assert len(patches) == 0
 
@@ -305,7 +305,7 @@ def test_phabricator_clang_format(
     ]
     list(map(lambda p: p.write(), revision.improvement_patches))  # trigger local write
 
-    issues, patches = reporter.publish([issue], revision, [], [])
+    issues, patches = reporter.publish([issue], revision, [], [], [])
     assert len(issues) == 1
     assert len(patches) == 1
 
@@ -363,7 +363,9 @@ def test_phabricator_mozlint(
     )
     assert issue_eslint.is_publishable()
 
-    issues, patches = reporter.publish([issue_flake, issue_eslint], revision, [], [])
+    issues, patches = reporter.publish(
+        [issue_flake, issue_eslint], revision, [], [], []
+    )
     assert len(issues) == 2
     assert len(patches) == 0
 
@@ -429,7 +431,7 @@ def test_phabricator_coverage(
     )
     assert issue.is_publishable()
 
-    issues, patches = reporter.publish([issue], revision, [], [])
+    issues, patches = reporter.publish([issue], revision, [], [], [])
     assert len(issues) == 1
     assert len(patches) == 0
 
@@ -500,7 +502,7 @@ def test_phabricator_clang_tidy_and_coverage(
     assert issue_coverage.is_publishable()
 
     issues, patches = reporter.publish(
-        [issue_clang_tidy, issue_coverage], revision, [], []
+        [issue_clang_tidy, issue_coverage], revision, [], [], []
     )
     assert len(issues) == 2
     assert len(patches) == 0
@@ -655,7 +657,7 @@ def test_phabricator_analyzers(
     ]
     list(map(lambda p: p.write(), revision.improvement_patches))  # trigger local write
 
-    issues, patches = reporter.publish(issues, revision, [], [])
+    issues, patches = reporter.publish(issues, revision, [], [], [])
 
     # Check issues & patches analyzers
     assert len(issues) == len(valid_issues)
@@ -700,7 +702,7 @@ def test_phabricator_clang_tidy_build_error(
 
         assert issue.is_publishable()
 
-        issues, patches = reporter.publish([issue], revision, [], [])
+        issues, patches = reporter.publish([issue], revision, [], [], [])
         assert len(issues) == 1
         assert len(patches) == 0
 
@@ -760,7 +762,7 @@ def test_full_file(mock_config, mock_phabricator, phab, mock_try_task, mock_task
     assert revision.has_file(issue.path)
     assert revision.contains(issue)
 
-    issues, patches = reporter.publish([issue], revision, [], [])
+    issues, patches = reporter.publish([issue], revision, [], [], [])
     assert len(issues) == 1
     assert len(patches) == 0
 
@@ -807,7 +809,7 @@ def test_task_failures(mock_phabricator, phab, mock_try_task):
         "status": {"runs": [{"runId": 0}]},
     }
     task = ClangTidyTask("ab3NrysvSZyEwsOHL2MZfw", status)
-    issues, patches = reporter.publish([], revision, [task], [])
+    issues, patches = reporter.publish([], revision, [task], [], [])
     assert len(issues) == 0
     assert len(patches) == 0
 
@@ -869,7 +871,7 @@ def test_extra_errors(mock_phabricator, mock_try_task, phab, mock_task):
         ),
     ]
 
-    published_issues, patches = reporter.publish(all_issues, revision, [], [])
+    published_issues, patches = reporter.publish(all_issues, revision, [], [], [])
     assert len(published_issues) == 2
     assert len(patches) == 0
 
@@ -931,6 +933,7 @@ def test_phabricator_notices(mock_phabricator, phab, mock_try_task):
         revision,
         [],
         notices,
+        [],
     )
 
     # Check the comment has been posted
@@ -948,6 +951,7 @@ def test_phabricator_notices(mock_phabricator, phab, mock_try_task):
         revision,
         [],
         notices,
+        [],
     )
 
     # Check the comment has been posted
@@ -979,6 +983,7 @@ def test_phabricator_tgdiff(mock_phabricator, phab, mock_try_task):
         revision,
         [],
         [doc_notice],
+        [],
     )
 
     # Check the comment has been posted
@@ -1027,7 +1032,7 @@ def test_phabricator_external_tidy(mock_phabricator, phab, mock_try_task, mock_t
     assert not issue_clang_diagnostic.is_publishable()
 
     issues, patches = reporter.publish(
-        [issue_civet_warning, issue_clang_diagnostic], revision, [], []
+        [issue_civet_warning, issue_clang_diagnostic], revision, [], [], []
     )
     assert len(issues) == 1
     assert len(patches) == 0
@@ -1066,7 +1071,7 @@ def test_phabricator_newer_diff(mock_phabricator, phab, mock_try_task, mock_task
     with capture_logs() as cap_logs:
         os.environ["SPECIAL_NAME"] = "PHID-DREV-zzzzz-updated"
 
-        issues, patches = reporter.publish([issue], revision, [], [])
+        issues, patches = reporter.publish([issue], revision, [], [], [])
 
         assert cap_logs == [
             # Log from PhabricatorReporter.publish_harbormaster(), it was still called
@@ -1198,7 +1203,7 @@ def test_phabricator_former_diff_comparison(
     os.environ["SPECIAL_NAME"] = "PHID-DREV-zzzzz-updated"
 
     with capture_logs() as cap_logs:
-        issues, patches = reporter.publish(issues, revision, [], [])
+        issues, patches = reporter.publish(issues, revision, [], [], [])
 
     assert cap_logs == [
         # Log from PhabricatorReporter.publish_harbormaster(), it was still called

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -983,8 +983,13 @@ def test_phabricator_tgdiff(mock_phabricator, phab, mock_try_task):
         revision,
         [],
         [doc_notice],
-        [],
+        ["taskgraph-reviewers"],
     )
+
+    # Check the reviewer group has been added to the revision
+    assert phab.transactions[51] == [
+        [{"type": "reviewers.add", "value": ["PHID-123456789-TGReviewers"]}]
+    ]
 
     # Check the comment has been posted
     assert phab.comments[51] == [VALID_NOTICE_MESSAGE.format(notice=doc_notice.strip())]

--- a/bot/tests/test_tgdiff_task.py
+++ b/bot/tests/test_tgdiff_task.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from code_review_bot.tasks.tgdiff import TaskGraphDiffTask
+
+
+@pytest.fixture
+def mock_taskgraph_diff_task():
+    tg_task_status = {
+        "task": {"metadata": {"name": "source-test-taskgraph-diff"}},
+        "status": {
+            "taskId": "12345deadbeef",
+            "state": "completed",
+            "runs": [{"runId": 0}],
+        },
+    }
+    return TaskGraphDiffTask("12345deadbeef", tg_task_status)
+
+
+def test_load_artifacts_no_summary(mock_taskcluster_config, mock_taskgraph_diff_task):
+    queue = mock_taskcluster_config.get_service("queue")
+    queue.options = {"rootUrl": "http://taskcluster.test"}
+    queue.configure(
+        {
+            "12345deadbeef": {
+                "artifacts": {
+                    "public/taskgraph/diffs/diff_mc-onpush.txt": "Some diff",
+                    "public/taskgraph/not_a_diff.txt": "Not a diff",
+                }
+            }
+        }
+    )
+
+    mock_taskgraph_diff_task.load_artifacts(queue)
+
+    assert mock_taskgraph_diff_task.artifact_urls == {
+        "public/taskgraph/diffs/diff_mc-onpush.txt": "http://tc.test/12345deadbeef/0/artifacts/public/taskgraph/diffs/diff_mc-onpush.txt"
+    }
+    assert mock_taskgraph_diff_task.extra_reviewers_groups == []
+
+
+def test_load_artifacts_ok_summary(mock_taskcluster_config, mock_taskgraph_diff_task):
+    queue = mock_taskcluster_config.get_service("queue")
+    queue.options = {"rootUrl": "http://taskcluster.test"}
+    queue.configure(
+        {
+            "12345deadbeef": {
+                "artifacts": {
+                    "public/taskgraph/diffs/diff_mc-onpush.txt": "Some diff",
+                    "public/taskgraph/diffs/summary.json": {
+                        "files": {},
+                        "status": "OK",
+                        "threshold": 20,
+                    },
+                    "public/taskgraph/not_a_diff.txt": "Not a diff",
+                }
+            }
+        }
+    )
+
+    mock_taskgraph_diff_task.load_artifacts(queue)
+
+    # The summary.json is OK, so no extra reviewer group is added and we don't load it in the artifact_urls list
+    assert mock_taskgraph_diff_task.artifact_urls == {
+        "public/taskgraph/diffs/diff_mc-onpush.txt": "http://tc.test/12345deadbeef/0/artifacts/public/taskgraph/diffs/diff_mc-onpush.txt"
+    }
+    assert mock_taskgraph_diff_task.extra_reviewers_groups == []
+
+
+def test_load_artifacts_warning_summary(
+    mock_taskcluster_config, mock_taskgraph_diff_task
+):
+    queue = mock_taskcluster_config.get_service("queue")
+    queue.options = {"rootUrl": "http://taskcluster.test"}
+    queue.configure(
+        {
+            "12345deadbeef": {
+                "artifacts": {
+                    "public/taskgraph/diffs/diff_mc-onpush.txt": "Some diff",
+                    "public/taskgraph/diffs/summary.json": {
+                        "files": {},
+                        "status": "WARNING",
+                        "threshold": 20,
+                    },
+                    "public/taskgraph/not_a_diff.txt": "Not a diff",
+                }
+            }
+        }
+    )
+
+    mock_taskgraph_diff_task.load_artifacts(queue)
+
+    # The summary.json is WARNING, so an extra reviewer group is added and we don't load it in the artifact_urls list
+    assert mock_taskgraph_diff_task.artifact_urls == {
+        "public/taskgraph/diffs/diff_mc-onpush.txt": "http://tc.test/12345deadbeef/0/artifacts/public/taskgraph/diffs/diff_mc-onpush.txt"
+    }
+    assert mock_taskgraph_diff_task.extra_reviewers_groups == ["taskgraph-reviewers"]


### PR DESCRIPTION
Depends on https://github.com/mozilla/libmozdata/pull/214 being merged + a new release for **libmozdata**

Closes #1475 