### PR TITLE
Make 'path' a parameter of the "Element is not valid" warning to allow better grouping

### DIFF
--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -299,7 +299,7 @@ class Revision(object):
         # Check in hgmo cache first
         cache_path = os.path.join(settings.hgmo_cache, path)
         if Path(settings.hgmo_cache) not in Path(cache_path).resolve().parents:
-            logger.warning(f"Element with path '{path}' is not valid")
+            logger.warning("Element is not valid for caching", path=path)
             raise ValueError
 
         if os.path.exists(cache_path):


### PR DESCRIPTION
Fixes #1583