### PR TITLE
Keep sentry-sdk to 1.22.2 for the moment

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -13,5 +13,5 @@ taskcluster==54.4.1
 treeherder-client==5.0.0
 # Please see #1416, this eventually must be removed!
 # Also this must be below 2.0.0 until we move sentry-sdk to 1.23
-urllib3==2.0.4
+urllib3==1.26.15
 yarl==1.9.2


### PR DESCRIPTION
sentry-sdk 1.23 and after has some issues with our code. COMMON_RECORD_ATTRS is not exposed directly in interations. 
The introduction of loguru to the sdk broke our integration.