### PR TITLE
Remove unneeded legacy scope docker-worker:capability:privileged

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -260,8 +260,6 @@ tasks:
                     expires: { $fromNow: "2 weeks" }
                     path: /events.tar.zst
                     type: file
-              scopes:
-                - docker-worker:capability:privileged
               metadata:
                 name: Code Review Events docker build
                 description: Build docker image of code review events
@@ -291,8 +289,6 @@ tasks:
                     expires: { $fromNow: "2 weeks" }
                     path: /backend.tar.zst
                     type: file
-              scopes:
-                - docker-worker:capability:privileged
               metadata:
                 name: Code Review Backend docker build
                 description: Build docker image of code review backend
@@ -353,8 +349,6 @@ tasks:
                     expires: { $fromNow: "2 weeks" }
                     path: /integration.tar.zst
                     type: file
-              scopes:
-                - docker-worker:capability:privileged
               metadata:
                 name: Code Review Integration docker build
                 description: Build docker image of code review integration tests


### PR DESCRIPTION
This was removed from repo scopes in https://github.com/mozilla/community-tc-config/commit/644bdf40bbe511957733d2f392c7c8fd9e240d89#diff-3763c36019cc481ce210456255ffad6215d1d446204879561298e54ca536dc4aL146-L147 and is no longer needed since migrating tasks from Docker Worker to Generic Worker.

Generic Worker runs tasks as podman rather than docker, and does not require any special privileges to run privileged tasks. The relevant code can be seen in d2g [here](https://github.com/taskcluster/taskcluster/blob/f6a5a511fa337c72574d6672aff4d1d8f1fb96b7/tools/d2g/d2g.go#L221-L223).