### PR TITLE
Reinstate legacy scope docker-worker:capability:privileged

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -260,6 +260,8 @@ tasks:
                     expires: { $fromNow: "2 weeks" }
                     path: /events.tar.zst
                     type: file
+              scopes:
+                - docker-worker:capability:privileged
               metadata:
                 name: Code Review Events docker build
                 description: Build docker image of code review events
@@ -289,6 +291,8 @@ tasks:
                     expires: { $fromNow: "2 weeks" }
                     path: /backend.tar.zst
                     type: file
+              scopes:
+                - docker-worker:capability:privileged
               metadata:
                 name: Code Review Backend docker build
                 description: Build docker image of code review backend
@@ -349,6 +353,8 @@ tasks:
                     expires: { $fromNow: "2 weeks" }
                     path: /integration.tar.zst
                     type: file
+              scopes:
+                - docker-worker:capability:privileged
               metadata:
                 name: Code Review Integration docker build
                 description: Build docker image of code review integration tests


### PR DESCRIPTION
This reverts PR #1834, reinstating `docker-worker:capability:privileged` scope where needed by Docker Worker.

This scope was removed as it was not needed by Generic Worker, however, it needs reinstating since worker pool `proj-relman/ci` has being (temporarily) reverted back to Docker Worker in #1856 until https://github.com/taskcluster/taskcluster/issues/6475 is fixed.

CC @marco-c @abpostelnicu 