### PR TITLE
bot: add the option to specify checker that shouldn't use before/after

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -134,7 +134,7 @@ class Issue(abc.ABC):
         This allow publishing issues based on other criteria, like in_patch.
         """
         if taskcluster.secrets.get(
-            f"{self.display_name.upper()}_DISABLE_PUBLICATION_BEFORE_AFTER", False
+            f"{self.analyzer.name.upper()}_DISABLE_PUBLICATION_BEFORE_AFTER", False
         ):
             return False
 


### PR DESCRIPTION
Add the ability to disable before/after for specific checkers based on config secrets.