### PR TITLE
Use podman rather img to build images

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -47,7 +47,7 @@ tasks:
         then: "https://api.code-review.testing.moz.tools"
         else: "https://api.code-review.moz.tools"
 
-    taskboot_image: "mozilla/taskboot:0.3.6"
+    taskboot_image: "mozilla/taskboot:0.4.1"
 
     pip_install: "pip install --disable-pip-version-check --no-cache-dir --quiet"
     python_version: "3.9"
@@ -63,7 +63,7 @@ tasks:
     workerType:
       $if: 'taskcluster_root_url == "https://firefox-ci-tc.services.mozilla.com"'
       then: linux-gcp
-      else: ci
+      else: generic-worker-ubuntu-22-04
   in:
     $if: 'tasks_for == "github-push" || (tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"])'
     then:


### PR DESCRIPTION
The `img` tool seems to be no longer actively maintained. Fuzzing also switched to podman in https://github.com/MozillaSecurity/orion/pull/242.

Credit to @matt-boris for the idea, finding the `BUILD_TOOL` env var, and discovering the fuzzing PR!