### PR TITLE
Update taskcluster-hook.json

### DIFF
--- a/integration/taskcluster-hook.json
+++ b/integration/taskcluster-hook.json
@@ -48,6 +48,7 @@
     "scopes": [
       "secrets:get:project/relman/code-review/integration-CHANNEL",
       "docker-worker:cache:code-review-integration-CHANNEL",
+      "generic-worker:cache:code-review-integration-CHANNEL",
       "notify:email:*"
     ],
     "tags": {},


### PR DESCRIPTION
Add generic-worker cache scope

Fixes failures like this https://community-tc.services.mozilla.com/tasks/BtnJ7KFrR6qKl9umM2MjEA/runs/0.