### PR TITLE
Use modern sentry SDK

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -5,13 +5,8 @@ async-timeout==4.0.3
 idna>=2.5,<3.8
 multidict==6.0.5
 rs_parsepatch==0.4.0
-# sentry-sdk 1.23 and after has some issues with our code, keep this until we fix it.
-# The introduction of loguru to the sdk broke our integration.
-sentry-sdk==2.6.0
+sentry-sdk==2.9.0
 structlog==24.2.0
 taskcluster==67.1.0
 treeherder-client==5.0.0
-# Please see #1416, this eventually must be removed!
-# Also this must be below 2.0.0 until we move sentry-sdk to 1.23
-urllib3==1.26.15
 yarl==1.9.4


### PR DESCRIPTION
Closes #2250
Closes #1416 
Closes #2234 
Closes #2209 
Closes #2249

In sentry 2.X the module `sentry_sdk.integrations.logging.COMMON_RECORD_ATTRS` is not available anymore.
Fortunately, we do not need it anymore, simply relying on internal features from recent `structlog`.

I tested these changes using this redacted snippet that enables both sentry & papertrail publication on test projects:

```python
from code_review_tools.log import init_logger
import structlog

init_logger(
    "bot",
    channel="dev",
    PAPERTRAIL_HOST="xxx.papertrailapp.com",
    PAPERTRAIL_PORT=yyy,
    SENTRY_DSN="https://whatever.ingest.us.sentry.io/zzzz"
)

logger = structlog.get_logger("test.log")
logger.info("This is Info")
logger.warning("This is warning")
logger.error("This is error", my="arg", test="ok")

print(1/ 0)
```

Here are screenshots showing how these few lines are logged on:

- local CLI output:
![cli](https://github.com/user-attachments/assets/4fd5931e-35dd-4f68-a98a-7ba2e820fff3)

- on papertrail: 
![Screenshot 2024-07-12 at 10-44-49 All Systems - Papertrail](https://github.com/user-attachments/assets/1f6d867a-4255-4fc2-a8cd-0cf94b3402a7)

- on sentry:
![Screenshot 2024-07-12 at 10-45-00 Issues — teklia — Sentry](https://github.com/user-attachments/assets/6f88c634-1a52-4a8a-8ce7-c4d7284cf07f)

We can see extra attributes are correctly shown on CLI & papertrail (in color now), but are not in the main Sentry message to still group similar events.