### PR TITLE
Use Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-exclude = .git,__pycache__,data,tools
-max-line-length = 88
-extend-ignore = E203,E501

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,3 +1,0 @@
-[settings]
-profile = black
-known_first_party = code_review_backend,code_review_bot,code_review_tools,code_review_events

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,17 @@
 repos:
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.4
     hooks:
-      - id: isort
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:
       - id: prettier
         exclude: fixtures|mocks
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-coding==1.3.2
-          - flake8-copyright==0.2.4
-          - flake8-debugger==4.1.2
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -5,6 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -213,9 +213,9 @@ class Revision(object):
 
         # Match the decision task environment to get the mercurial information
         decision_env = decision_task["payload"]["env"]
-        head_repository = (
-            base_repository
-        ) = head_changeset = base_changeset = repository_try_name = None
+        head_repository = base_repository = head_changeset = base_changeset = (
+            repository_try_name
+        ) = None
         for prefix in settings.decision_env_prefixes:
             head_repository_key = f"{prefix}_HEAD_REPOSITORY"
             base_repository_key = f"{prefix}_BASE_REPOSITORY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.ruff]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I", "T10", "CPY"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["code_review_backend", "code_review_bot", "code_review_tools", "code_review_events"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 
 [tool.ruff.lint]
-select = ["W", "E", "F", "I", "T10", "CPY"]
+select = ["W", "E", "F", "I", "T10"]
 ignore = [
 	# Line too long
 	"E501",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,11 @@
 [tool.ruff]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I", "T10", "CPY"]
+select = ["W", "E", "F", "I", "T10", "CPY"]
+ignore = [
+	# Line too long
+	"E501",
+]
 
 [tool.ruff.lint.isort]
 known-first-party = ["code_review_backend", "code_review_bot", "code_review_tools", "code_review_events"]


### PR DESCRIPTION
Refs #2192 

This replaces flake8, isort and black by ruff linter & formatter.

I started from the [bugbug ruff config](https://github.com/mozilla/bugbug/pull/4031) and extended it a bit to cover all pycodestyle rules (except line too long)
