### PR TITLE
restrict on push builds to `master` and `production` in taskcluster

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -66,7 +66,7 @@ tasks:
       then: linux-gw-gcp
       else: generic-worker-ubuntu-24-04
   in:
-    $if: 'tasks_for == "github-push" || (tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"])'
+    $if: '(tasks_for == "github-push" && (head_branch == "master" || head_branch == "production" || head_branch == "testing")) || (tasks_for == "github-pull-request" && event["action"] in ["opened", "reopened", "synchronize"])'
     then:
       $flatten:
         $match:


### PR DESCRIPTION
In https://bugzilla.mozilla.org/show_bug.cgi?id=1907217 we're making scopes more explicit for branches. Because of this, pushes to branches not named in that repository will not be able to run. If this will be problematic, or we need to add more branches to this list, please let me know and we'll sort it out!