### PR TITLE
Remove repository filters in cleanup_issues command

### DIFF
--- a/backend/code_review_backend/issues/management/commands/cleanup_issues.py
+++ b/backend/code_review_backend/issues/management/commands/cleanup_issues.py
@@ -12,15 +12,13 @@ from django.utils import timezone
 
 from code_review_backend.issues.models import Diff, Issue, IssueLink, Revision
 
-logging.basicConfig(level=logging.INFO)
-
 logger = logging.getLogger(__name__)
 
 DEL_CHUNK_SIZE = 500
 
 
 class Command(BaseCommand):
-    help = "Cleanup old issues from autoland and mozilla-central repositories"
+    help = "Cleanup old issues from all repositories"
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -34,8 +32,6 @@ class Command(BaseCommand):
         clean_until = timezone.now() - timedelta(days=options["nb_days"])
 
         rev_to_delete = Revision.objects.filter(
-            base_repository__slug__in=["autoland", "mozilla-central"],
-            head_repository__slug__in=["autoland", "mozilla-central"],
             created__lte=clean_until,
         )
         total_rev_count = rev_to_delete.count()
@@ -45,7 +41,7 @@ class Command(BaseCommand):
             return
 
         logger.info(
-            f"Retrieved {total_rev_count} old revisions from either autoland or mozilla-central to be deleted."
+            f"Retrieved {total_rev_count} old revisions to be deleted."
         )
 
         stats = defaultdict(int)

--- a/backend/code_review_backend/issues/management/commands/cleanup_issues.py
+++ b/backend/code_review_backend/issues/management/commands/cleanup_issues.py
@@ -40,9 +40,7 @@ class Command(BaseCommand):
             logger.info("Didn't find any old revision to delete.")
             return
 
-        logger.info(
-            f"Retrieved {total_rev_count} old revisions to be deleted."
-        )
+        logger.info(f"Retrieved {total_rev_count} old revisions to be deleted.")
 
         stats = defaultdict(int)
 

--- a/backend/code_review_backend/issues/tests/commands/test_cleanup_issues.py
+++ b/backend/code_review_backend/issues/tests/commands/test_cleanup_issues.py
@@ -62,7 +62,7 @@ class CleanupIssuesCommandTestCase(TestCase):
                     head_repository=repo,
                 )
                 for i, repo in enumerate(
-                    (self.moz_central, self.test_repo, self.autoland)
+                    (self.moz_central, self.autoland, self.test_repo)
                 )
             ]
         )

--- a/backend/code_review_backend/issues/tests/commands/test_cleanup_issues.py
+++ b/backend/code_review_backend/issues/tests/commands/test_cleanup_issues.py
@@ -62,7 +62,7 @@ class CleanupIssuesCommandTestCase(TestCase):
                     head_repository=repo,
                 )
                 for i, repo in enumerate(
-                    (self.moz_central, self.autoland, self.test_repo)
+                    (self.moz_central, self.test_repo, self.autoland)
                 )
             ]
         )
@@ -122,7 +122,7 @@ class CleanupIssuesCommandTestCase(TestCase):
         self.assertListEqual(
             mock_log.output,
             [
-                f"{LOG_PREFIX}Retrieved 1 old revisions from either autoland or mozilla-central to be deleted.",
+                f"{LOG_PREFIX}Retrieved 1 old revisions to be deleted.",
                 f"{LOG_PREFIX}Page 1/1.",
                 f"{LOG_PREFIX}Deleted 4 IssueLink, 1 Diff, 2 Issue, 1 Revision.",
             ],
@@ -143,7 +143,7 @@ class CleanupIssuesCommandTestCase(TestCase):
         self.assertEqual(
             mock_log.output,
             [
-                f"{LOG_PREFIX}Retrieved 2 old revisions from either autoland or mozilla-central to be deleted.",
+                f"{LOG_PREFIX}Retrieved 2 old revisions to be deleted.",
                 f"{LOG_PREFIX}Page 1/1.",
                 f"{LOG_PREFIX}Deleted 6 IssueLink, 1 Diff, 4 Issue, 2 Revision.",
             ],


### PR DESCRIPTION
Refs #1539 

I simply remove the repository filters to process all revisions no matter where they come from.

The `logging.basicConfig` is removed, as it became useless since sentry+logging update.