### PR TITLE
Docker compose stack

### DIFF
--- a/backend/code_review_backend/app/settings.py
+++ b/backend/code_review_backend/app/settings.py
@@ -104,7 +104,8 @@ if "DATABASE_URL" in os.environ:
         "default": dj_database_url.parse(
             os.environ["DATABASE_URL"],
             conn_max_age=600,
-            ssl_require="DYNO" in os.environ,
+            ssl_require="DYNO" in os.environ
+            and os.environ.get("DATABASE_NO_SSL") is None,
         )
     }
 else:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,29 @@
 ---
 services:
+  backend:
+    container_name: code-review-backend
+    build:
+      dockerfile: ./backend/Dockerfile
+      context: .
+
+    environment:
+      DATABASE_URL: postgresql://devuser:devdata@db/code_review_dev
+
+      # Setup environment like on Heroku
+      DYNO: 1
+      HOST: 0.0.0.0
+      PORT: 80
+      SECRET_KEY: randomSecretKey123
+
+      # Special marker to skip SSL for Postgres
+      DATABASE_NO_SSL: 1
+
+    ports:
+      - 127.0.0.1:8000:80
+
+    depends_on:
+      - db
+
   db:
     container_name: code-review-db
     image: postgres:16-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+---
+services:
+  db:
+    container_name: code-review-db
+    image: postgres:16-alpine
+
+    ports:
+      - 127.0.0.1:5432:5432
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: devuser
+      POSTGRES_PASSWORD: devdata
+      POSTGRES_DB: code_review_dev
+
+volumes:
+  pgdata:
+    driver: local

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -30,5 +30,5 @@ You can download the backup from the Heroku datastore dedicated page.
 
 ```bash
 export PGPASSWORD=devdata
-pg_restore  -h localhost --user devuser -d code_review_dev path/to/dump
+pg_restore -h localhost --user devuser -d code_review_dev path/to/dump
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,8 +4,31 @@ A `docker-compose.yml` file is available to reproduce locally the code-review st
 
 Run it with `docker-compose up`
 
+## Use the backend
+
+A backend instance will be available as http://localhost:8000
+
+You can initialize the database with:
+
+```
+docker exec code-review-backend python manage.py migrate
+```
+
+You can create an admin account:
+
+```
+docker exec -it code-review-backend python manage.py createsuperuser
+```
+
+Then you can login on http://localhost:8000/admin/
+
 ## Restore a backend postgres dump
 
+The database must be empty (no `migrate`) to be able to restore a backup.
+
+You can download the backup from the Heroku datastore dedicated page.
+
 ```bash
+export PGPASSWORD=devdata
 pg_restore  -h localhost --user devuser -d code_review_dev path/to/dump
 ```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,11 @@
+# Docker stack
+
+A `docker-compose.yml` file is available to reproduce locally the code-review stack.
+
+Run it with `docker-compose up`
+
+## Restore a backend postgres dump
+
+```bash
+pg_restore  -h localhost --user devuser -d code_review_dev path/to/dump
+```


### PR DESCRIPTION
Refs #1539 

In order to reproduce locally the heroku stack I built this simple docker-compose stack with the Postgres DB & backend running.

This allows me to load an Heroku dump and use it from the backend either in docker or in dev mode