### PR TITLE
Remove ANSI color codes from sentry events

### DIFF
--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -866,3 +866,17 @@ class MockPhabricator:
 @pytest.fixture
 def phab():
     return MockPhabricator("http://phabricator.test", "deadbeef")
+
+
+@pytest.fixture
+def sentry_event_with_colors():
+    path = os.path.join(FIXTURES_DIR, "sentry_event_before.json")
+    with open(path) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def sentry_event_without_colors():
+    path = os.path.join(FIXTURES_DIR, "sentry_event_after.json")
+    with open(path) as f:
+        return json.load(f)

--- a/bot/tests/fixtures/sentry_event_after.json
+++ b/bot/tests/fixtures/sentry_event_after.json
@@ -1,0 +1,125 @@
+{
+    "breadcrumbs": {
+        "values": [
+            {
+                "category": "test.log",
+                "data": {
+                    "asctime": "2024-08-01 16:31:37"
+                },
+                "level": "info",
+                "message": "[info     ] This is Info                  ",
+                "timestamp": "2024-08-01T14:31:37.784756Z",
+                "type": "log"
+            },
+            {
+                "category": "test.log",
+                "data": {
+                    "asctime": "2024-08-01 16:31:37"
+                },
+                "level": "warning",
+                "message": "[warning  ] This is warning               ",
+                "timestamp": "2024-08-01T14:31:37.785234Z",
+                "type": "log"
+            }
+        ]
+    },
+    "contexts": {
+        "runtime": {
+            "build": "3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]",
+            "name": "CPython",
+            "version": "3.10.12"
+        },
+        "trace": {
+            "dynamic_sampling_context": {
+                "environment": "dev",
+                "public_key": "3e4688ab0490667ddf863da3c8b074b3",
+                "release": "1.6.2",
+                "trace_id": "d6c4832c2380477c9f28efb0c5e36cdb"
+            },
+            "parent_span_id": null,
+            "span_id": "83670bdf42178356",
+            "trace_id": "d6c4832c2380477c9f28efb0c5e36cdb"
+        }
+    },
+    "environment": "dev",
+    "event_id": "6d93a346184743359d003cefb0371ce5",
+    "extra": {
+        "asctime": "2024-08-01 16:31:37",
+        "sys.argv": [
+            "log.py"
+        ]
+    },
+    "level": "error",
+    "logentry": {
+        "message": "[error    ] This is error                  my=arg test=ok",
+        "params": []
+    },
+    "logger": "test.log",
+    "modules": {
+        "aiohttp": "3.9.5",
+        "aiosignal": "1.3.1",
+        "async-timeout": "4.0.3",
+        "attrs": "22.2.0",
+        "certifi": "2022.12.7",
+        "charset-normalizer": "2.1.1",
+        "code-review-bot": "1.6.2",
+        "code-review-tools": "0.2.0",
+        "frozenlist": "1.3.3",
+        "icalendar": "5.0.4",
+        "idna": "3.4",
+        "influxdb": "5.3.1",
+        "libmozdata": "0.1.83",
+        "mohawk": "1.1.0",
+        "msgpack": "1.0.4",
+        "multidict": "6.0.5",
+        "pip": "22.0.2",
+        "python-dateutil": "2.8.2",
+        "python-hglib": "2.6.2",
+        "pytz": "2022.7.1",
+        "pyyaml": "6.0",
+        "requests": "2.28.2",
+        "requests-futures": "1.0.0",
+        "rs_parsepatch": "0.4.0",
+        "sentry-sdk": "2.11.0",
+        "setuptools": "59.6.0",
+        "six": "1.16.0",
+        "slugid": "2.0.0",
+        "structlog": "24.4.0",
+        "taskcluster": "67.1.0",
+        "taskcluster-urls": "13.0.1",
+        "treeherder-client": "5.0.0",
+        "urllib3": "1.26.14",
+        "whatthepatch": "1.0.4",
+        "wheel": "0.37.1",
+        "yarl": "1.9.4"
+    },
+    "platform": "python",
+    "release": "1.6.2",
+    "sdk": {
+        "integrations": [
+            "aiohttp",
+            "argv",
+            "atexit",
+            "dedupe",
+            "excepthook",
+            "logging",
+            "modules",
+            "stdlib",
+            "threading"
+        ],
+        "name": "sentry.python.aiohttp",
+        "packages": [
+            {
+                "name": "pypi:sentry-sdk",
+                "version": "2.11.0"
+            }
+        ],
+        "version": "2.11.0"
+    },
+    "server_name": "bot",
+    "tags": {
+        "site": "unknown"
+    },
+    "timestamp": "2024-08-01T14:31:37.819483Z",
+    "transaction_info": {}
+}

--- a/bot/tests/fixtures/sentry_event_before.json
+++ b/bot/tests/fixtures/sentry_event_before.json
@@ -1,0 +1,125 @@
+{
+    "breadcrumbs": {
+        "values": [
+            {
+                "category": "test.log",
+                "data": {
+                    "asctime": "2024-08-01 16:31:37"
+                },
+                "level": "info",
+                "message": "[\u001b[32m\u001b[1minfo     \u001b[0m] \u001b[1mThis is Info                  \u001b[0m",
+                "timestamp": "2024-08-01T14:31:37.784756Z",
+                "type": "log"
+            },
+            {
+                "category": "test.log",
+                "data": {
+                    "asctime": "2024-08-01 16:31:37"
+                },
+                "level": "warning",
+                "message": "[\u001b[33m\u001b[1mwarning  \u001b[0m] \u001b[1mThis is warning               \u001b[0m",
+                "timestamp": "2024-08-01T14:31:37.785234Z",
+                "type": "log"
+            }
+        ]
+    },
+    "contexts": {
+        "runtime": {
+            "build": "3.10.12 (main, Mar 22 2024, 16:50:05) [GCC 11.4.0]",
+            "name": "CPython",
+            "version": "3.10.12"
+        },
+        "trace": {
+            "dynamic_sampling_context": {
+                "environment": "dev",
+                "public_key": "3e4688ab0490667ddf863da3c8b074b3",
+                "release": "1.6.2",
+                "trace_id": "d6c4832c2380477c9f28efb0c5e36cdb"
+            },
+            "parent_span_id": null,
+            "span_id": "83670bdf42178356",
+            "trace_id": "d6c4832c2380477c9f28efb0c5e36cdb"
+        }
+    },
+    "environment": "dev",
+    "event_id": "6d93a346184743359d003cefb0371ce5",
+    "extra": {
+        "asctime": "2024-08-01 16:31:37",
+        "sys.argv": [
+            "log.py"
+        ]
+    },
+    "level": "error",
+    "logentry": {
+        "message": "[\u001b[31m\u001b[1merror    \u001b[0m] \u001b[1mThis is error                 \u001b[0m \u001b[36mmy\u001b[0m=\u001b[35marg\u001b[0m \u001b[36mtest\u001b[0m=\u001b[35mok\u001b[0m",
+        "params": []
+    },
+    "logger": "test.log",
+    "modules": {
+        "aiohttp": "3.9.5",
+        "aiosignal": "1.3.1",
+        "async-timeout": "4.0.3",
+        "attrs": "22.2.0",
+        "certifi": "2022.12.7",
+        "charset-normalizer": "2.1.1",
+        "code-review-bot": "1.6.2",
+        "code-review-tools": "0.2.0",
+        "frozenlist": "1.3.3",
+        "icalendar": "5.0.4",
+        "idna": "3.4",
+        "influxdb": "5.3.1",
+        "libmozdata": "0.1.83",
+        "mohawk": "1.1.0",
+        "msgpack": "1.0.4",
+        "multidict": "6.0.5",
+        "pip": "22.0.2",
+        "python-dateutil": "2.8.2",
+        "python-hglib": "2.6.2",
+        "pytz": "2022.7.1",
+        "pyyaml": "6.0",
+        "requests": "2.28.2",
+        "requests-futures": "1.0.0",
+        "rs_parsepatch": "0.4.0",
+        "sentry-sdk": "2.11.0",
+        "setuptools": "59.6.0",
+        "six": "1.16.0",
+        "slugid": "2.0.0",
+        "structlog": "24.4.0",
+        "taskcluster": "67.1.0",
+        "taskcluster-urls": "13.0.1",
+        "treeherder-client": "5.0.0",
+        "urllib3": "1.26.14",
+        "whatthepatch": "1.0.4",
+        "wheel": "0.37.1",
+        "yarl": "1.9.4"
+    },
+    "platform": "python",
+    "release": "1.6.2",
+    "sdk": {
+        "integrations": [
+            "aiohttp",
+            "argv",
+            "atexit",
+            "dedupe",
+            "excepthook",
+            "logging",
+            "modules",
+            "stdlib",
+            "threading"
+        ],
+        "name": "sentry.python.aiohttp",
+        "packages": [
+            {
+                "name": "pypi:sentry-sdk",
+                "version": "2.11.0"
+            }
+        ],
+        "version": "2.11.0"
+    },
+    "server_name": "bot",
+    "tags": {
+        "site": "unknown"
+    },
+    "timestamp": "2024-08-01T14:31:37.819483Z",
+    "transaction_info": {}
+}

--- a/bot/tests/test_tools.py
+++ b/bot/tests/test_tools.py
@@ -5,6 +5,8 @@
 import pytest
 from taskcluster.helper import TaskclusterConfig
 
+from code_review_tools.log import remove_color_codes
+
 
 def test_taskcluster_service():
     """
@@ -18,3 +20,13 @@ def test_taskcluster_service():
     with pytest.raises(AssertionError) as e:
         taskcluster.get_service("nope")
     assert str(e.value) == "Invalid Taskcluster service nope"
+
+
+def test_remove_color_codes(sentry_event_with_colors, sentry_event_without_colors):
+    """
+    Test the removal of color codes from Sentry payloads
+    """
+    assert (
+        remove_color_codes(sentry_event_with_colors, hint=None)
+        == sentry_event_without_colors
+    )

--- a/tools/code_review_tools/log.py
+++ b/tools/code_review_tools/log.py
@@ -5,6 +5,7 @@
 import logging
 import logging.handlers
 import os
+import re
 
 import pkg_resources
 import sentry_sdk
@@ -12,6 +13,23 @@ import structlog
 from sentry_sdk.integrations.logging import LoggingIntegration
 
 root = logging.getLogger()
+
+# Found on https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+# 7-bit C1 ANSI sequences
+ANSI_ESCAPE = re.compile(
+    r"""
+    \x1B  # ESC
+    (?:   # 7-bit C1 Fe (except CSI)
+        [@-Z\\-_]
+    |     # or [ for CSI, followed by a control sequence
+        \[
+        [0-?]*  # Parameter bytes
+        [ -/]*  # Intermediate bytes
+        [@-~]   # Final byte
+    )
+""",
+    re.VERBOSE,
+)
 
 
 class AppNameFilter(logging.Filter):
@@ -45,11 +63,37 @@ def setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT):
     root.addHandler(papertrail)
 
 
+def remove_color_codes(event, hint):
+    """
+    Remove ANSI color codes from a Sentry event before it gets published
+    """
+
+    def _remove(content):
+        try:
+            return ANSI_ESCAPE.sub("", content)
+        except Exception as e:
+            # Do not log here, rely on simple print
+            print(f"Failed to remove color code: {e}")
+            return content
+
+    # Remove from breadcrumb
+    breadcrumbs = event.get("breadcrumbs", {})
+    for value in breadcrumbs.get("values", []):
+        if "message" in value:
+            value["message"] = _remove(value["message"])
+
+    # Remove from log entry
+    logentry = event.get("logentry", {})
+    if "message" in logentry:
+        logentry["message"] = _remove(logentry["message"])
+
+    return event
+
+
 def setup_sentry(name, channel, dsn):
     """
     Setup sentry account using taskcluster secrets
     """
-
     # Detect environment
     task_id = os.environ.get("TASK_ID")
     if task_id is not None:
@@ -73,6 +117,7 @@ def setup_sentry(name, channel, dsn):
         server_name=name,
         environment=channel,
         release=pkg_resources.get_distribution(f"code-review-{name}").version,
+        before_send=remove_color_codes,
     )
     sentry_sdk.set_tag("site", site)
 


### PR DESCRIPTION
Closes #2288 

This removes all ANSI color codes from any event being sent to Sentry. This supports breadcrumbs (context for sentry) and log messages.
The code is a bit defensive as the payload may vary across events

Here is a screenshot of my test Sentry project with both versions from master & this PR

![Screenshot 2024-08-01 at 16-39-49 Issues — teklia — Sentry](https://github.com/user-attachments/assets/886c42cf-fad8-456d-b489-4765bb798ce9)
