### PR TITLE
Configure libmozdata from tools

### DIFF
--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -22,6 +22,7 @@ from code_review_bot.config import settings
 from code_review_bot.report import get_reporters
 from code_review_bot.revisions import Revision
 from code_review_bot.workflow import Workflow
+from code_review_tools.libmozdata import setup as setup_libmozdata
 from code_review_tools.log import init_logger
 
 logger = structlog.get_logger(__name__)
@@ -96,6 +97,9 @@ def main():
         PAPERTRAIL_PORT=taskcluster.secrets.get("PAPERTRAIL_PORT"),
         SENTRY_DSN=taskcluster.secrets.get("SENTRY_DSN"),
     )
+
+    # Setup libmozdata configuration
+    setup_libmozdata("code-review-bot")
 
     # Setup settings before stats
     settings.setup(

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -1,6 +1,5 @@
 -e ../tools #egg=code-review-tools
 influxdb==5.3.2
-libmozdata==0.2.8
 python-hglib==2.6.2
 pyyaml==6.0.2
 setuptools==75.1.0

--- a/events/code_review_events/cli.py
+++ b/events/code_review_events/cli.py
@@ -7,6 +7,7 @@ import yaml
 
 from code_review_events import community_taskcluster_config, taskcluster_config
 from code_review_events.workflow import Events
+from code_review_tools.libmozdata import setup as setup_libmozdata
 from code_review_tools.log import init_logger
 
 logger = structlog.get_logger(__name__)
@@ -72,6 +73,9 @@ def main():
         PAPERTRAIL_PORT=taskcluster_config.secrets.get("PAPERTRAIL_PORT"),
         SENTRY_DSN=taskcluster_config.secrets.get("SENTRY_DSN"),
     )
+
+    # Setup libmozdata configuration
+    setup_libmozdata("code-review-events")
 
     events = Events(args.cache_root)
     events.run()

--- a/events/requirements.txt
+++ b/events/requirements.txt
@@ -2,7 +2,6 @@ aioamqp==0.15.0
 -e ../tools #egg=code-review-tools
 json-e==4.8.0
 jsonschema==4.23.0
-libmozdata==0.2.8
 libmozevent==1.1.28
 python-hglib==2.6.2
 pytoml==0.1.21

--- a/tools/code_review_tools/libmozdata.py
+++ b/tools/code_review_tools/libmozdata.py
@@ -1,0 +1,31 @@
+from importlib.metadata import version
+
+import structlog
+from libmozdata.config import Config, set_config
+
+logger = structlog.get_logger(__name__)
+
+
+class LocalConfig(Config):
+    """
+    Provide required configuration for libmozdata
+    using in-memory class instead of an INI file
+    """
+
+    def __init__(self, name, version):
+        self.user_agent = f"{name}/{version}"
+        logger.debug(f"User agent is {self.user_agent}")
+
+    def get(self, section, option, default=None, **kwargs):
+        if section == "User-Agent" and option == "name":
+            return self.user_agent
+
+        return default
+
+
+def setup(package_name):
+    # Get version for main package
+    package_version = version(package_name)
+
+    # Provide to custom libzmodata configuration
+    set_config(LocalConfig(package_name, package_version))

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,6 +3,7 @@ async-timeout==4.0.3
 
 # Limit idna to avid conflicts
 idna>=2.5,<3.11
+libmozdata==0.2.8
 multidict==6.1.0
 rs_parsepatch==0.4.4
 sentry-sdk==2.16.0


### PR DESCRIPTION
This PR configures libmozdata using a local Configuration classs, that does not rely on files but instead build dynamically the user agent by looking up the provided package version.

There is no file to add in the Docker image, and the version in the user agent always increment.