### PR TITLE
remove dependency on async-timeout

### DIFF
--- a/bot/tests/fixtures/sentry_event_after.json
+++ b/bot/tests/fixtures/sentry_event_after.json
@@ -58,7 +58,6 @@
     "modules": {
         "aiohttp": "3.9.5",
         "aiosignal": "1.3.1",
-        "async-timeout": "4.0.3",
         "attrs": "22.2.0",
         "certifi": "2022.12.7",
         "charset-normalizer": "2.1.1",

--- a/bot/tests/fixtures/sentry_event_before.json
+++ b/bot/tests/fixtures/sentry_event_before.json
@@ -58,7 +58,6 @@
     "modules": {
         "aiohttp": "3.9.5",
         "aiosignal": "1.3.1",
-        "async-timeout": "4.0.3",
         "attrs": "22.2.0",
         "certifi": "2022.12.7",
         "charset-normalizer": "2.1.1",

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,5 +1,4 @@
 aiohttp==3.10.10
-async-timeout==4.0.3
 
 # Limit idna to avid conflicts
 idna>=2.5,<3.11


### PR DESCRIPTION
Library aiohttp had dropped async-timeout asrequirement on Python 3.11+ systems in version 3.9.0.