### PR TITLE
Fix Issue.hash max length in migration

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -202,7 +202,7 @@ tasks:
                   - "git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b checks &&
                     cd /src/tools && ${pip_install} . &&
                     cd /src/backend && ${pip_install} . && ${pip_install} -r requirements-dev.txt &&
-                    ./manage.py test"
+                    ./manage.py test && ./manage.py makemigrations --check --noinput --dry-run -v 3"
               metadata:
                 name: "Code Review Backend checks: unit tests"
                 description: Check python code with Django tests

--- a/backend/code_review_backend/issues/migrations/0014_unique_hash.py
+++ b/backend/code_review_backend/issues/migrations/0014_unique_hash.py
@@ -61,6 +61,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name="issue",
             name="hash",
-            field=models.CharField(max_length=250, unique=True),
+            field=models.CharField(max_length=32, unique=True),
         ),
     ]


### PR DESCRIPTION
I found out that the commited version of the 0014 migration is incomplete (mismatching max length).

It's not a big deal as it did not run on prod yet, but to avoid this in the future I also added a CI check that will prevent merging invalid migration states