### PR TITLE
Do not crash on unsupported tasks

### DIFF
--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -443,6 +443,7 @@ class Workflow:
                     continue
                 artifacts = task.load_artifacts(self.queue_service)
                 if artifacts is not None:
+                    task_issues, task_patches = [], []
                     if isinstance(task, AnalysisTask):
                         task_issues = task.parse_issues(artifacts, revision)
                         logger.info(


### PR DESCRIPTION
Closes #2508 

The bug is trivial to fix, but the [task](https://firefox-ci-tc.services.mozilla.com/tasks/BHDyOiRpTeCWly7D90XTNw) that triggered the exception is unsupported.

A log line now mentions it in the bot execution with this patch:

```
2024-11-13 09:38:44.000441 [WARNING ] [warning  ] Missing firefox-source-docs-url.txt
2024-11-13 09:38:44.000442 [WARNING ] [warning  ] An erroneous task processed some artifacts and found no issues or patches id=BHDyOiRpTeCWly7D90XTNw task=source-test-doc-upload
```

As mentionned, this is due to `public/firefox-source-docs-url.txt` artifact missing. We cannot do much more on the bot side