### PR TITLE
Preserve initial issues order during bulk create

### DIFF
--- a/backend/code_review_backend/issues/serializers.py
+++ b/backend/code_review_backend/issues/serializers.py
@@ -294,7 +294,6 @@ class IssueBulkSerializer(serializers.Serializer):
                 "issue_links__nb_lines",
                 "issue_links__char",
             )
-            .order_by("id")
         )
         # Group existing links by issue
         grouped_issues = [


### PR DESCRIPTION
This should fix backend unit tests and allow another push on testing (last one [did not complete](https://community-tc.services.mozilla.com/tasks/groups/D10BRBUGTt2OtsxVcO0V5w))