### PR TITLE
Filter fetched existing issues by revision and diff

### DIFF
--- a/backend/code_review_backend/issues/serializers.py
+++ b/backend/code_review_backend/issues/serializers.py
@@ -274,7 +274,7 @@ class IssueBulkSerializer(serializers.Serializer):
             ignore_conflicts=True,
         )
         # List issues again to ensure ID are synced for creating links
-        issues_with_links = (
+        issues_with_links = list(
             Issue.objects.values("issue_links")
             .filter(
                 hash__in=[issue.hash for issue in issues],
@@ -298,6 +298,7 @@ class IssueBulkSerializer(serializers.Serializer):
                 "issue_links__nb_lines",
                 "issue_links__char",
             )
+            .iterator()
         )
         # Group existing links by issue
         grouped_issues = [

--- a/backend/code_review_backend/issues/serializers.py
+++ b/backend/code_review_backend/issues/serializers.py
@@ -276,7 +276,11 @@ class IssueBulkSerializer(serializers.Serializer):
         # List issues again to ensure ID are synced for creating links
         issues_with_links = (
             Issue.objects.values("issue_links")
-            .filter(hash__in=[issue.hash for issue in issues])
+            .filter(
+                hash__in=[issue.hash for issue in issues],
+                issue_links__diff_id=(diff and diff.id),
+                issue_links__revision_id=self.context["revision"].id,
+            )
             # Needed for re-serialization
             .annotate(publishable=Q(issue_links__in_patch=True) & Q(level=LEVEL_ERROR))
             .values(

--- a/backend/code_review_backend/issues/serializers.py
+++ b/backend/code_review_backend/issues/serializers.py
@@ -277,9 +277,16 @@ class IssueBulkSerializer(serializers.Serializer):
         issues_with_links = list(
             Issue.objects.values("issue_links")
             .filter(
+                Q(
+                    # Issue is new for this diff/revision
+                    issue_links__isnull=True,
+                )
+                | Q(
+                    # Issue exists for this diff/revision
+                    issue_links__diff=diff,
+                    issue_links__revision=self.context["revision"],
+                ),
                 hash__in=[issue.hash for issue in issues],
-                issue_links__diff_id=(diff and diff.id),
-                issue_links__revision_id=self.context["revision"].id,
             )
             # Needed for re-serialization
             .annotate(publishable=Q(issue_links__in_patch=True) & Q(level=LEVEL_ERROR))

--- a/backend/code_review_backend/issues/tests/test_api.py
+++ b/backend/code_review_backend/issues/tests/test_api.py
@@ -419,7 +419,6 @@ class CreationAPITestCase(APITestCase):
         )
 
         # Calling again with the same payload should give the same result
-        # 1 less request is fired to the DB because no IssueLink is created
         with self.assertNumQueries(5):
             response = self.client.post(
                 f"/v1/revision/{self.revision.id}/issues/", payload_2, format="json"


### PR DESCRIPTION
Closes #2516

The approach by chunk would make the code more complex and still slow. I think the main issue here was the number of IssueLink returned by the JOIN. On my DB 10 hashes may return thousands of links.

I added a filter by revision/diff for existing issues. The estimated cost in pgadmin dropped from max `49265.77` to max `91.8` on my database. I also added an iterator() to be sure we avoid a memory issue there.