### PR TITLE
Support autoland on Revision.__repr__

### DIFF
--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -155,7 +155,15 @@ class Revision:
         random.seed(os.urandom(128))
 
     def __repr__(self):
-        return self.diff_phid
+        if self.diff_phid:
+            # Most revisions have a Diff from Phabricator
+            return self.diff_phid or "Unidentified revision"
+        elif self.head_changeset:
+            # Autoland revisions have no diff
+            return f"{self.head_changeset}@{self.head_repository}"
+        else:
+            # Fallback
+            return "Unknown revision"
 
     def __str__(self):
         return f"Phabricator #{self.diff_id} - {self.diff_phid}"

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -319,6 +319,17 @@ def mock_revision(mock_phabricator, mock_try_task, mock_decision_task, mock_conf
         return Revision.from_try_task(mock_try_task, mock_decision_task, api)
 
 
+@pytest.fixture
+def mock_revision_autoland(mock_phabricator, mock_autoland_task):
+    """
+    Mock a mercurial revision from autoland repo
+    """
+    from code_review_bot.revisions import Revision
+
+    with mock_phabricator as api:
+        return Revision.from_decision_task(mock_autoland_task, api)
+
+
 class Response:
     "A simple response encoded as JSON"
 

--- a/bot/tests/test_revisions.py
+++ b/bot/tests/test_revisions.py
@@ -69,6 +69,30 @@ def test_phabricator(mock_config, mock_revision):
     ]
 
 
+def test_autoland(mock_config, mock_revision_autoland):
+    """
+    Test a revision coming from a decision task (meaning autoland)
+    """
+    assert mock_revision_autoland.diff_id is None
+    assert mock_revision_autoland.diff_phid is None
+    assert mock_revision_autoland.url is None
+    assert (
+        mock_revision_autoland.head_repository
+        == "https://hg.mozilla.org/integration/autoland"
+    )
+    assert mock_revision_autoland.head_changeset == "deadbeef123"
+    assert (
+        mock_revision_autoland.base_repository
+        == "https://hg.mozilla.org/mozilla-unified"
+    )
+    assert mock_revision_autoland.base_changeset == "123deadbeef"
+
+    assert (
+        repr(mock_revision_autoland)
+        == "deadbeef123@https://hg.mozilla.org/integration/autoland"
+    )
+
+
 def test_clang_files(mock_revision):
     """
     Test clang files detection


### PR DESCRIPTION
Closes https://mozilla.sentry.io/issues/6064254923

Refs #2260 

This prevents the bot from crashing when a revision has no diff set and the `repr` method is called on the revision.

This only happens in the [main error handling case](https://github.com/mozilla/code-review/blob/master/bot/code_review_bot/cli.py#L202-L204) for autoland revisions, but it prevents the bot from reporting error state on both phabricator & lando.

Here is an [example task](https://firefox-ci-tc.services.mozilla.com/tasks/S8p_nBz-RUe-GVrK05pCZg/runs/0/logs/public/logs/live.log) where this happen.

