### PR TITLE
Simplify bulk issues creation

### DIFF
--- a/backend/code_review_backend/issues/tests/test_api.py
+++ b/backend/code_review_backend/issues/tests/test_api.py
@@ -423,7 +423,7 @@ class CreationAPITestCase(APITestCase):
         )
 
         # Calling again with the same payload should give the same result
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(6):
             response = self.client.post(
                 f"/v1/revision/{self.revision.id}/issues/", payload_2, format="json"
             )

--- a/backend/code_review_backend/issues/tests/test_api.py
+++ b/backend/code_review_backend/issues/tests/test_api.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import unittest
+
 from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -341,6 +343,11 @@ class CreationAPITestCase(APITestCase):
         self.assertFalse(link.new_for_revision)
         self.assertEqual(link.line, 1)
 
+    # This test is currently expected to fail due to the unique
+    # constraints on IssueLink not respecting the NULL values unicity
+    # So we end up with duplicate IssueLinks being created when NULL values
+    # are used for (line, nb_lines, char)
+    @unittest.expectedFailure
     def test_create_issue_bulk_alread_exists(self):
         """
         You cannot try to create the same issue twice through the bulk endpoint


### PR DESCRIPTION
Refs #2260 

Closes https://mozilla.sentry.io/issues/6072452921 (a lot of 500s on both instances)

I noticed an important issue on the backend that prevent issues creation when an issue is already linked to a revision through a previous diff. This case happens often now that we have de-duplicated issues.

The bulk endpoint was iterated over recently, bringing too much complexity.

I was able to simplify it so it runs in 4 steps:
1. create all issues in a single `bulk_create` call, using unicity constraints to prevent duplications
2. retrieve all issues from DB to get existing IDs (as bulk_create otherwise provides its generated but non-commited IDs)
3. directly create all issue links in a single `bulk_create` call, using unicity constraints to prevent duplications
4. build list of dicts for specific serializations

This removes support for an edge-case: calling multiple times the endpoint with the same payload  with `NULL` values in line, char, nb_lines will re-create the same `IssueLink`.
This case should never happen in practice, but the existing DB constraint does not catch it due to [a Database limitation](https://docs.djangoproject.com/en/5.1/ref/models/constraints/#nulls-distinct). I'll file an issue to work on 

