### PR TITLE
Revert libmozevent to 1.1.28

### DIFF
--- a/events/requirements.txt
+++ b/events/requirements.txt
@@ -2,7 +2,7 @@ aioamqp==0.15.0
 -e ../tools #egg=code-review-tools
 json-e==4.8.0
 jsonschema==4.23.0
-libmozevent==1.1.29
+libmozevent==1.1.28
 python-hglib==2.6.2
 pytoml==0.1.21
 pyyaml==6.0.2


### PR DESCRIPTION
This reverts commit 0b66468383f1b34f7045e0ccbce5a4cd52a007ae.

The usage of [this patch](https://github.com/mozilla/libmozevent/commit/3ce10c6e164d25169acaef878eb36e103b147fce) seems invalid, as it raises https://mozilla.sentry.io/issues/6075721195