### PR TITLE
Clone repo in normal workflow (no before/after)

### DIFF
--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -122,6 +122,10 @@ class Workflow:
                 f"Found {new_issues_count} new issues (over {len(issues)} total detected issues)",
                 task=settings.try_group_id,
             )
+        else:
+            # Clone local repo when required
+            # as publication need the hashes
+            self.clone_repository(revision)
 
         if (
             all(issue.new_issue is False for issue in issues)


### PR DESCRIPTION
I noticed that this allows us to use local clone without running before/after (which is enabled on testing but is not always wanted on prod).