### PR TITLE
Port events workflow to bot

### DIFF
--- a/bot/code_review_bot/analysis.py
+++ b/bot/code_review_bot/analysis.py
@@ -113,7 +113,7 @@ def publish_analysis_phabricator(payload, phabricator_api):
                 namespace="code-review",
                 name="mercurial",
                 result=UnitResultState.Unsound,
-                details=f"WARNING: The base revision of your patch is not available in the current repository.\nYour patch has been rebased on central (revision {build.actual_base_revision}): issues may be positioned on the wrong lines.",
+                details=f"WARNING: The base revision of your patch is not available in the current repository.\nYour patch has been rebased on central (revision {build.actual_base_revision}): issues may be positioned at the wrong lines.",
             )
             phabricator_api.update_build_target(
                 build.target_phid, BuildState.Work, unit=[warning]

--- a/bot/code_review_bot/analysis.py
+++ b/bot/code_review_bot/analysis.py
@@ -26,22 +26,38 @@ class RevisionBuild(PhabricatorBuild):
         # Incremented on an unexpected failure during build's push to try
         self.retries = 0
 
+        # Revision used by Phabricator updates
+        # Direct output of Phabricator API (not the object passed here)
+        self.revision_url = None
+        self.revision = None
+
+        # Needed to update Phabricator Harbormaster
+        self.target_phid = revision.build_target_phid
+
         # Needed to load stack of patches
         self.diff = revision.diff
         self.diff_id = revision.diff_id
         self.stack = None
 
+        # Needed to apply patch and communicate on Phabricator
+        self.base_revision = None
+        self.actual_base_revision = None
+        self.missing_base_revision = False
+
     def __str__(self):
         return f"Phabricator Diff {self.diff_id}"
 
 
-def publish_results(self, payload):
-    if not self.publish:
-        logger.debug("Skipping Phabricator publication")
+def publish_analysis_phabricator(payload, phabricator_api):
+    mode, build, extras = payload
+
+    if build.target_phid is None:
+        logger.warning(
+            "No Phabricator build target, so no publication", mode=mode, build=build
+        )
         return
 
-    mode, build, extras = payload
-    logger.debug("Publishing a Phabricator build update", mode=mode, build=build)
+    logger.info("Publishing a Phabricator build update", mode=mode, build=build)
 
     if mode == "fail:general":
         failure = UnitResult(
@@ -54,22 +70,9 @@ def publish_results(self, payload):
             format="remarkup",
             duration=extras.get("duration", 0),
         )
-        if self.lando_publish_failure:
-            # Send general failure message to Lando
-            if self.publish_lando:
-                logger.info(
-                    "Publishing code review failure.",
-                    revision=build.revision["id"],
-                    diff=build.diff_id,
-                )
-                try:
-                    self.lando_warnings.add_warning(
-                        LANDO_FAILURE_MESSAGE, build.revision["id"], build.diff_id
-                    )
-                except Exception as ex:
-                    logger.error(str(ex), exc_info=True)
-
-        self.api.update_build_target(build.target_phid, BuildState.Fail, unit=[failure])
+        phabricator_api.update_build_target(
+            build.target_phid, BuildState.Fail, unit=[failure]
+        )
 
     elif mode == "fail:mercurial":
         extra_content = ""
@@ -86,20 +89,9 @@ def publish_results(self, payload):
             format="remarkup",
             duration=extras.get("duration", 0),
         )
-        # Send mercurial message to Lando
-        if self.publish_lando:
-            logger.info(
-                "Publishing code review hg failure.",
-                revision=build.revision["id"],
-                diff=build.diff_id,
-            )
-            try:
-                self.lando_warnings.add_warning(
-                    LANDO_FAILURE_HG_MESSAGE, build.revision["id"], build.diff_id
-                )
-            except Exception as ex:
-                logger.error(str(ex), exc_info=True)
-        self.api.update_build_target(build.target_phid, BuildState.Fail, unit=[failure])
+        phabricator_api.update_build_target(
+            build.target_phid, BuildState.Fail, unit=[failure]
+        )
 
     elif mode == "test_result":
         result = UnitResult(
@@ -108,7 +100,9 @@ def publish_results(self, payload):
             result=extras["result"],
             details=extras["details"],
         )
-        self.api.update_build_target(build.target_phid, BuildState.Work, unit=[result])
+        phabricator_api.update_build_target(
+            build.target_phid, BuildState.Work, unit=[result]
+        )
 
     elif mode == "success":
         if build.missing_base_revision:
@@ -121,14 +115,14 @@ def publish_results(self, payload):
                 result=UnitResultState.Unsound,
                 details=f"WARNING: The base revision of your patch is not available in the current repository.\nYour patch has been rebased on central (revision {build.actual_base_revision}): issues may be positioned on the wrong lines.",
             )
-            self.api.update_build_target(
+            phabricator_api.update_build_target(
                 build.target_phid, BuildState.Work, unit=[warning]
             )
             logger.debug(
                 "Missing base revision on PhabricatorBuild, adding a warning to Unit Tests section on Phabricator"
             )
 
-        self.api.create_harbormaster_uri(
+        phabricator_api.create_harbormaster_uri(
             build.target_phid,
             "treeherder",
             "CI (Treeherder) Jobs",
@@ -136,8 +130,56 @@ def publish_results(self, payload):
         )
 
     elif mode == "work":
-        self.api.update_build_target(build.target_phid, BuildState.Work)
+        phabricator_api.update_build_target(build.target_phid, BuildState.Work)
         logger.info("Published public build as working", build=str(build))
 
     else:
         logger.warning("Unsupported publication", mode=mode, build=build)
+
+
+def publish_analysis_lando(payload, lando_warnings):
+    mode, build, extras = payload
+    logger.debug("Publishing a Lando build update", mode=mode, build=build)
+
+    if mode == "fail:general":
+        # Send general failure message to Lando
+        logger.info(
+            "Publishing code review failure.",
+            revision=build.revision["id"],
+            diff=build.diff_id,
+        )
+        try:
+            lando_warnings.add_warning(
+                LANDO_FAILURE_MESSAGE, build.revision["id"], build.diff_id
+            )
+        except Exception as ex:
+            logger.error(str(ex), exc_info=True)
+
+    elif mode == "fail:mercurial":
+        # Send mercurial message to Lando
+        logger.info(
+            "Publishing code review hg failure.",
+            revision=build.revision["id"],
+            diff=build.diff_id,
+        )
+        try:
+            lando_warnings.add_warning(
+                LANDO_FAILURE_HG_MESSAGE, build.revision["id"], build.diff_id
+            )
+        except Exception as ex:
+            logger.error(str(ex), exc_info=True)
+
+    elif mode == "success":
+        logger.info(
+            "Begin publishing init warning message to lando.",
+            revision=build.revision["id"],
+            diff=build.diff_id,
+        )
+        try:
+            lando_warnings.add_warning(
+                LANDO_WARNING_MESSAGE, build.revision["id"], build.diff_id
+            )
+        except Exception as ex:
+            logger.error(str(ex), exc_info=True)
+    else:
+        logger.info("Nothing to publish on Lando", mode=mode, build=build)

--- a/bot/code_review_bot/analysis.py
+++ b/bot/code_review_bot/analysis.py
@@ -2,8 +2,6 @@ import structlog
 from libmozdata.phabricator import BuildState, UnitResult, UnitResultState
 from libmozevent.phabricator import PhabricatorBuild, PhabricatorBuildState
 
-from code_review_bot.revisions import Revision
-
 logger = structlog.get_logger(__name__)
 
 
@@ -17,6 +15,10 @@ LANDO_FAILURE_HG_MESSAGE = (
 
 
 class RevisionBuild(PhabricatorBuild):
+    """
+    Convert the bot revision into a libmozevent compatible build
+    """
+
     def __init__(self, revision):
         # State should be updated to Public
         self.state = PhabricatorBuildState.Queued
@@ -31,14 +33,6 @@ class RevisionBuild(PhabricatorBuild):
 
     def __str__(self):
         return f"Phabricator Diff {self.diff_id}"
-
-
-def convert_revision_to_build(revision: Revision) -> RevisionBuild:
-    """
-    Convert the bot revision into a libmozevent compatible build
-    """
-
-    return RevisionBuild(revision)
 
 
 def publish_results(self, payload):

--- a/bot/code_review_bot/analysis.py
+++ b/bot/code_review_bot/analysis.py
@@ -1,8 +1,6 @@
 import structlog
 from libmozdata.phabricator import BuildState, UnitResult, UnitResultState
-from libmozevent.phabricator import (
-    PhabricatorBuild,
-)
+from libmozevent.phabricator import PhabricatorBuild, PhabricatorBuildState
 
 from code_review_bot.revisions import Revision
 
@@ -19,8 +17,20 @@ LANDO_FAILURE_HG_MESSAGE = (
 
 
 class RevisionBuild(PhabricatorBuild):
-    def __init__(self):
-        pass
+    def __init__(self, revision):
+        # State should be updated to Public
+        self.state = PhabricatorBuildState.Queued
+
+        # Incremented on an unexpected failure during build's push to try
+        self.retries = 0
+
+        # Needed to load stack of patches
+        self.diff = revision.diff
+        self.diff_id = revision.diff_id
+        self.stack = None
+
+    def __str__(self):
+        return f"Phabricator Diff {self.diff_id}"
 
 
 def convert_revision_to_build(revision: Revision) -> RevisionBuild:
@@ -28,7 +38,7 @@ def convert_revision_to_build(revision: Revision) -> RevisionBuild:
     Convert the bot revision into a libmozevent compatible build
     """
 
-    return RevisionBuild()
+    return RevisionBuild(revision)
 
 
 def publish_results(self, payload):

--- a/bot/code_review_bot/analysis.py
+++ b/bot/code_review_bot/analysis.py
@@ -1,0 +1,139 @@
+import structlog
+from libmozdata.phabricator import BuildState, UnitResult, UnitResultState
+from libmozevent.phabricator import (
+    PhabricatorBuild,
+)
+
+from code_review_bot.revisions import Revision
+
+logger = structlog.get_logger(__name__)
+
+
+LANDO_WARNING_MESSAGE = "Static analysis and linting are still in progress."
+LANDO_FAILURE_MESSAGE = (
+    "Static analysis and linting did not run due to a generic failure."
+)
+LANDO_FAILURE_HG_MESSAGE = (
+    "Static analysis and linting did not run due to failure in applying the patch."
+)
+
+
+class RevisionBuild(PhabricatorBuild):
+    def __init__(self):
+        pass
+
+
+def convert_revision_to_build(revision: Revision) -> RevisionBuild:
+    """
+    Convert the bot revision into a libmozevent compatible build
+    """
+
+    return RevisionBuild()
+
+
+def publish_results(self, payload):
+    if not self.publish:
+        logger.debug("Skipping Phabricator publication")
+        return
+
+    mode, build, extras = payload
+    logger.debug("Publishing a Phabricator build update", mode=mode, build=build)
+
+    if mode == "fail:general":
+        failure = UnitResult(
+            namespace="code-review",
+            name="general",
+            result=UnitResultState.Broken,
+            details="WARNING: An error occurred in the code review bot.\n\n```{}```".format(
+                extras["message"]
+            ),
+            format="remarkup",
+            duration=extras.get("duration", 0),
+        )
+        if self.lando_publish_failure:
+            # Send general failure message to Lando
+            if self.publish_lando:
+                logger.info(
+                    "Publishing code review failure.",
+                    revision=build.revision["id"],
+                    diff=build.diff_id,
+                )
+                try:
+                    self.lando_warnings.add_warning(
+                        LANDO_FAILURE_MESSAGE, build.revision["id"], build.diff_id
+                    )
+                except Exception as ex:
+                    logger.error(str(ex), exc_info=True)
+
+        self.api.update_build_target(build.target_phid, BuildState.Fail, unit=[failure])
+
+    elif mode == "fail:mercurial":
+        extra_content = ""
+        if build.missing_base_revision:
+            extra_content = f" because the parent revision ({build.base_revision}) does not exist on mozilla-unified. If possible, you should publish that revision"
+
+        failure = UnitResult(
+            namespace="code-review",
+            name="mercurial",
+            result=UnitResultState.Fail,
+            details="WARNING: The code review bot failed to apply your patch{}.\n\n```{}```".format(
+                extra_content, extras["message"]
+            ),
+            format="remarkup",
+            duration=extras.get("duration", 0),
+        )
+        # Send mercurial message to Lando
+        if self.publish_lando:
+            logger.info(
+                "Publishing code review hg failure.",
+                revision=build.revision["id"],
+                diff=build.diff_id,
+            )
+            try:
+                self.lando_warnings.add_warning(
+                    LANDO_FAILURE_HG_MESSAGE, build.revision["id"], build.diff_id
+                )
+            except Exception as ex:
+                logger.error(str(ex), exc_info=True)
+        self.api.update_build_target(build.target_phid, BuildState.Fail, unit=[failure])
+
+    elif mode == "test_result":
+        result = UnitResult(
+            namespace="code-review",
+            name=extras["name"],
+            result=extras["result"],
+            details=extras["details"],
+        )
+        self.api.update_build_target(build.target_phid, BuildState.Work, unit=[result])
+
+    elif mode == "success":
+        if build.missing_base_revision:
+            # Publish a warning message on Phabricator in the Unit Tests section,
+            # as done for other warnings/errors from the bot, since this section
+            # is centered and at the top of the page.
+            warning = UnitResult(
+                namespace="code-review",
+                name="mercurial",
+                result=UnitResultState.Unsound,
+                details=f"WARNING: The base revision of your patch is not available in the current repository.\nYour patch has been rebased on central (revision {build.actual_base_revision}): issues may be positioned on the wrong lines.",
+            )
+            self.api.update_build_target(
+                build.target_phid, BuildState.Work, unit=[warning]
+            )
+            logger.debug(
+                "Missing base revision on PhabricatorBuild, adding a warning to Unit Tests section on Phabricator"
+            )
+
+        self.api.create_harbormaster_uri(
+            build.target_phid,
+            "treeherder",
+            "CI (Treeherder) Jobs",
+            extras["treeherder_url"],
+        )
+
+    elif mode == "work":
+        self.api.update_build_target(build.target_phid, BuildState.Work)
+        logger.info("Published public build as working", build=str(build))
+
+    else:
+        logger.warning("Unsupported publication", mode=mode, build=build)

--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -157,6 +157,12 @@ def main():
             revision = Revision.from_decision_task(
                 queue_service.task(settings.mozilla_central_group_id), phabricator_api
             )
+        elif settings.phabricator_revision_phid:
+            revision = Revision.from_phabricator_trigger(
+                settings.phabricator_revision_phid,
+                settings.phabricator_transactions,
+                phabricator_api,
+            )
         else:
             revision = Revision.from_try_task(
                 queue_service.task(settings.try_task_id),
@@ -195,6 +201,8 @@ def main():
             w.ingest_revision(revision, settings.autoland_group_id)
         elif settings.mozilla_central_group_id:
             w.ingest_revision(revision, settings.mozilla_central_group_id)
+        elif settings.phabricator_revision_phid:
+            w.start_analysis(revision)
         else:
             w.run(revision)
     except Exception as e:

--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -70,7 +70,7 @@ def main():
 
     taskcluster.load_secrets(
         args.taskcluster_secret,
-        prefixes=["common", "code-review-bot", "bot"],
+        prefixes=["common", "events", "code-review-bot", "bot"],
         required=(
             "APP_CHANNEL",
             "REPORTERS",
@@ -84,6 +84,7 @@ def main():
             "ZERO_COVERAGE_ENABLED": True,
             "ALLOWED_PATHS": ["*"],
             "task_failures_ignored": [],
+            "ssh_key": None,
         },
         local_secrets=yaml.safe_load(args.configuration)
         if args.configuration
@@ -106,6 +107,7 @@ def main():
         taskcluster.secrets["APP_CHANNEL"],
         taskcluster.secrets["ALLOWED_PATHS"],
         taskcluster.secrets["repositories"],
+        taskcluster.secrets["ssh_key"],
         args.mercurial_repository,
     )
 

--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -85,6 +85,7 @@ def main():
             "ALLOWED_PATHS": ["*"],
             "task_failures_ignored": [],
             "ssh_key": None,
+            "user_blacklist": [],
         },
         local_secrets=yaml.safe_load(args.configuration)
         if args.configuration
@@ -148,6 +149,9 @@ def main():
                 "publish_failure"
             ]
             reporters["lando"].setup_api(lando_api)
+
+    # We need Phabricator API to list black-listed users
+    settings.load_user_blacklist(taskcluster.secrets["user_blacklist"], phabricator_api)
 
     # Load unique revision
     try:

--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -65,6 +65,10 @@ class Settings:
         # SSH Key used to push on try
         self.ssh_key = None
 
+        # List of users that should trigger a new analysis
+        # Indexed by their Phabricator ID
+        self.user_blacklist = {}
+
         # Always cleanup at the end of the execution
         atexit.register(self.cleanup)
         # caching the versions of the app
@@ -158,6 +162,18 @@ class Settings:
 
             # Save ssh key when mercurial cache is enabled
             self.ssh_key = ssh_key
+
+    def load_user_blacklist(self, usernames, phabricator_api):
+        """
+        Load all black listed users from Phabricator API
+        """
+        self.user_blacklist = {
+            user["phid"]: user["fields"]["username"]
+            for user in phabricator_api.search_users(
+                constraints={"usernames": usernames}
+            )
+        }
+        logger.info("Blacklisted users", names=self.user_blacklist.values())
 
     def __getattr__(self, key):
         if key not in self.config:

--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -6,6 +6,7 @@
 import atexit
 import collections
 import fnmatch
+import json
 import os
 import shutil
 import tempfile
@@ -47,6 +48,8 @@ class Settings:
         self.try_group_id = None
         self.autoland_group_id = None
         self.mozilla_central_group_id = None
+        self.phabricator_revision_phid = None
+        self.phabricator_transactions = None
         self.repositories = []
         self.decision_env_prefixes = []
 
@@ -73,6 +76,22 @@ class Settings:
             self.autoland_group_id = os.environ["AUTOLAND_TASK_GROUP_ID"]
         elif "MOZILLA_CENTRAL_TASK_GROUP_ID" in os.environ:
             self.mozilla_central_group_id = os.environ["MOZILLA_CENTRAL_TASK_GROUP_ID"]
+        elif (
+            "PHABRICATOR_OBJECT_PHID" in os.environ
+            and "PHABRICATOR_TRANSACTIONS" in os.environ
+        ):
+            # Setup trigger mode using Phabricator information
+            self.phabricator_revision_phid = os.environ["PHABRICATOR_OBJECT_PHID"]
+            assert self.phabricator_revision_phid.startswith(
+                "PHID-DREV"
+            ), f"Not a phabrication revision PHID: {self.phabricator_revision_phid}"
+            try:
+                self.phabricator_transactions = json.loads(
+                    os.environ["PHABRICATOR_TRANSACTIONS"]
+                )
+            except Exception as e:
+                logger.error("Failed to parse phabricator transactions", err=str(e))
+                raise
         else:
             raise Exception("Only TRY mode is supported")
 

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -477,6 +477,19 @@ class Revision:
 
         return any(_is_idl(f) for f in self.files)
 
+    @property
+    def is_blacklisted(self):
+        """Check if the revision author is in the black-list"""
+        # TODO: finalize port
+        return False
+
+        author = self.user_blacklist.get(self.fields["authorPHID"])
+        if author is None:
+            return False
+
+        logger.info("Revision from a blacklisted user", revision=self, author=author)
+        return True
+
     def add_improvement_patch(self, analyzer, content):
         """
         Save an improvement patch, and make it available

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -532,10 +532,7 @@ class Revision:
     @property
     def is_blacklisted(self):
         """Check if the revision author is in the black-list"""
-        # TODO: finalize port
-        return False
-
-        author = self.user_blacklist.get(self.fields["authorPHID"])
+        author = settings.user_blacklist.get(self.revision["fields"]["authorPHID"])
         if author is None:
             return False
 

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -315,14 +315,14 @@ class Workflow:
         if self.update_build:
             publish_analysis_phabricator(output, self.phabricator)
         else:
-            logger.debug("Skipping Phabricator publication")
+            logger.info("Skipping Phabricator publication")
 
         # Send Build in progress or errors to Lando
         lando_reporter = self.reporters.get("lando")
         if lando_reporter is not None:
             publish_analysis_lando(output, lando_reporter.lando_api)
         else:
-            logger.debug("Skipping Lando publication")
+            logger.info("Skipping Lando publication")
 
     def clone_repository(self, revision):
         """

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -275,7 +275,7 @@ class Workflow:
             # so we can initialize with empty data here
             queue_name=None,
             queue_phabricator=None,
-            repositories=None,
+            repositories={},
         )
 
         while build.retries > 0:

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -303,6 +303,10 @@ class Workflow:
             logger.warning(
                 "Failed to load build details", build=str(build), error=str(e)
             )
+            raise
+
+        if not build.stack:
+            raise Exception("No stack of patches to apply.")
 
         # We'll clone the required repository
         repository.clone()

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -312,14 +312,15 @@ class Workflow:
         output = asyncio.run(worker.handle_build(repository, build))
 
         # Update final state using worker output
-        if self.publish:
+        if self.update_build:
             publish_analysis_phabricator(output, self.phabricator)
         else:
             logger.debug("Skipping Phabricator publication")
 
         # Send Build in progress or errors to Lando
-        if self.publish_lando:
-            publish_analysis_lando(output, self.lando_warnings)
+        lando_reporter = self.reporters.get("lando")
+        if lando_reporter is not None:
+            publish_analysis_lando(output, lando_reporter.lando_api)
         else:
             logger.debug("Skipping Lando publication")
 

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -228,7 +228,7 @@ class Workflow:
         """
         Apply a patch on a local clone and push to try to trigger a new Code review analysis
         """
-        logger.info("Starting revision analysis", revivion=revision)
+        logger.info("Starting revision analysis", revision=revision)
 
         # Do not process revisions from black-listed users
         if revision.is_blacklisted:

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -215,6 +215,18 @@ class Workflow:
         # Publish issues in the backend
         self.backend_api.publish_issues(issues, revision)
 
+    def start_analysis(self, revision):
+        """
+        Apply a patch on a local clone and push to try to trigger a new Code review analysis
+        """
+        logger.info("Patch should be applied here...")
+
+        # TODO: clone upstream at tip
+
+        # TODO: apply stack of patches
+
+        # TODO: push to try
+
     def clone_repository(self, revision):
         """
         Clone the repo locally when configured

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -1,6 +1,6 @@
 -e ../tools #egg=code-review-tools
 influxdb==5.3.2
-libmozevent==1.1.28
+libmozevent==1.1.30
 python-hglib==2.6.2
 pyyaml==6.0.2
 setuptools==75.8.0

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -1,5 +1,6 @@
 -e ../tools #egg=code-review-tools
 influxdb==5.3.2
+libmozevent==1.1.28
 python-hglib==2.6.2
 pyyaml==6.0.2
 setuptools==75.8.0

--- a/bot/tests/mocks/phabricator_build_search.json
+++ b/bot/tests/mocks/phabricator_build_search.json
@@ -4,7 +4,8 @@
             {
               "fields": {
                 "buildablePHID": "PHID-HMXX-test"
-              }
+              },
+              "phid": "PHID-HMBD-test"
             }
         ],
         "maps": {},

--- a/bot/tests/mocks/phabricator_buildable_search.json
+++ b/bot/tests/mocks/phabricator_buildable_search.json
@@ -4,7 +4,8 @@
             {
               "fields": {
                 "objectPHID": "PHID-DIFF-test"
-              }
+              },
+              "phid": "PHID-HMBB-test"
             }
         ],
         "maps": {},

--- a/bot/tests/mocks/phabricator_diff_search_PHID-DIFF-testABcd12.json
+++ b/bot/tests/mocks/phabricator_diff_search_PHID-DIFF-testABcd12.json
@@ -1,0 +1,63 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 456,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-testABcd12",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-zzzzz",
+                    "authorPHID": "PHID-USER-xxxxx",
+                    "repositoryPHID": "PHID-REPO-autoland",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "deadbeef123"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                    "commits": {
+                        "commits": [
+                            {
+                                "identifier": "deadbeef123",
+                                "tree": null,
+                                "parents": [
+                                    "someNode"
+                                ],
+                                "author": {
+                                    "name": "test",
+                                    "email": "test@mozilla.com",
+                                    "raw": "\"test\" <test>",
+                                    "epoch": 0
+                                },
+                                "message": "Random commit message"
+                            }
+                        ]
+                    }
+                }
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}

--- a/bot/tests/mocks/phabricator_edge_search.json
+++ b/bot/tests/mocks/phabricator_edge_search.json
@@ -1,8 +1,6 @@
 {
     "result": {
         "data": [
-          {"destinationPHID": 1},
-          {"destinationPHID": 2}
         ],
         "maps": {},
         "query": {

--- a/bot/tests/mocks/phabricator_project_search.json
+++ b/bot/tests/mocks/phabricator_project_search.json
@@ -1,0 +1,50 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 1,
+                "type": "PROJ",
+                "phid": "PHID-PROJ-secure",
+                "fields": {
+                    "name": "secure-revision",
+                    "slug": "secure-revision",
+                    "subtype": "default",
+                    "milestone": null,
+                    "depth": 0,
+                    "parent": null,
+                    "icon": {
+                        "key": "policy",
+                        "name": "Policy",
+                        "icon": "fa-lock"
+                    },
+                    "color": {
+                        "key": "blue",
+                        "name": "Blue"
+                    },
+                    "spacePHID": null,
+                    "dateCreated": 1519855816,
+                    "dateModified": 1683298448,
+                    "policy": {
+                        "view": "public",
+                        "edit": "admin",
+                        "join": "admin"
+                    },
+                    "description": "The revision contains sensitive information and email should not be sent in the clear."
+                },
+                "attachments": {}
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}

--- a/bot/tests/mocks/phabricator_target_search.json
+++ b/bot/tests/mocks/phabricator_target_search.json
@@ -4,7 +4,8 @@
             {
               "fields": {
                 "buildPHID": "PHID-HMBB-xxx"
-              }
+              },
+              "phid": "PHID-HMBT-test"
             }
         ],
         "maps": {},

--- a/bot/tests/mocks/phabricator_transaction_search.json
+++ b/bot/tests/mocks/phabricator_transaction_search.json
@@ -23,7 +23,7 @@
                 "comments": [],
                 "fields": {
                     "old": "PHID-DIFF-3imcuyzrmmhdpgrr5w6r",
-                    "new": "PHID-DIFF-iu3aoh7r2r3dt6mifdyi",
+                    "new": "PHID-DIFF-test",
                     "commitPHIDs": []
                 }
             },

--- a/bot/tests/test_analysis.py
+++ b/bot/tests/test_analysis.py
@@ -2,11 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
+import tempfile
+
+from libmozevent import utils
+
 from code_review_bot.config import RepositoryConf
 from code_review_bot.revisions import Revision
 
 
-def test_revision(mock_autoland_task, mock_phabricator, mock_hgmo):
+def test_revision(mock_phabricator):
     """
     Validate the creation of a Revision in analysis context
     using Phabricator webhook payload
@@ -49,3 +54,167 @@ def test_revision(mock_autoland_task, mock_phabricator, mock_hgmo):
         ssh_user="reviewbot@mozilla.com",
     )
     assert revision.repository_try_name == "try"
+
+
+def test_workflow(
+    mock_mercurial_repo,
+    mock_phabricator,
+    mock_workflow,
+    mock_config,
+    tmpdir,
+    monkeypatch,
+):
+    """
+    Validate the creation of a Revision in analysis context
+    using Phabricator webhook payload
+    """
+
+    # Enable clone & push in settings
+    mock_config.mercurial_cache = tmpdir
+    mock_config.ssh_key = "Dummy Private SSH Key"
+
+    # Capture hg calls
+    hgrun_calls = []
+
+    def mock_hgrun(cmd):
+        hgrun_calls.append(cmd)
+
+    monkeypatch.setattr(utils, "hg_run", mock_hgrun)
+
+    # Control ssh key destination
+    ssh_key_path = tmpdir / "ssh.key"
+    monkeypatch.setattr(tempfile, "mkstemp", lambda suffix: (None, ssh_key_path))
+
+    # Create repo dir to write try task config
+    repo_path = tmpdir / "mozilla-central"
+    repo_path.mkdir()
+
+    # Run the analysis on fake revision
+    with mock_phabricator as api:
+        mock_workflow.phabricator = api
+
+        revision = Revision.from_phabricator_trigger(
+            revision_phid="PHID-DREV-1234",
+            transactions=[
+                "PHID-XACT-aaaa",
+            ],
+            phabricator=api,
+        )
+
+        mock_workflow.start_analysis(revision)
+
+    # Check hgrun initial call to clone mozilla central through robust checkout
+    assert hgrun_calls == [
+        [
+            "robustcheckout",
+            b"--purge",
+            f"--sharebase={tmpdir}/mozilla-central-shared".encode(),
+            b"--branch=tip",
+            b"--",
+            "https://hg.mozilla.org/mozilla-central",
+            repo_path,
+        ]
+    ]
+
+    # Check try task config has been written with code-review trigger
+    try_task = tmpdir / "mozilla-central" / "try_task_config.json"
+    assert try_task.exists()
+    assert json.load(try_task.open()) == {
+        "parameters": {
+            "optimize_target_tasks": True,
+            "phabricator_diff": "PHID-HMBT-test",
+            "target_tasks_method": "codereview",
+        },
+        "version": 2,
+    }
+
+    # Check all calls made to mercurial repo
+    assert mock_mercurial_repo._calls == [
+        # Cleanup
+        "cbout",
+        "cberr",
+        (
+            "revert",
+            str(repo_path).encode(),
+            {
+                "all": True,
+            },
+        ),
+        (
+            "rawcommand",
+            [
+                b"strip",
+                b"--rev=roots(outgoing())",
+                b"--force",
+            ],
+        ),
+        # Pull
+        "pull",
+        (
+            "identify",
+            "coffeedeadbeef123456789",
+        ),
+        (
+            "identify",
+            "coffeedeadbeef123456789",
+        ),
+        # Checkout revision
+        (
+            "update",
+            {
+                "clean": True,
+                "rev": "coffeedeadbeef123456789",
+            },
+        ),
+        (
+            "status",
+            {
+                "added": True,
+                "deleted": True,
+                "modified": True,
+                "removed": True,
+            },
+        ),
+        # Apply patch
+        (
+            "import",
+            b"diff --git a/test.txt b/test.txt\nindex 557db03..5eb0bec 100644\n-"
+            b"-- a/test.txt\n+++ b/test.txt\n@@ -1 +1,2 @@\n Hello World\n+Second "
+            b"line\ndiff --git a/test.cpp b/test.cpp\nnew file mode 100644\nindex"
+            b" 000000..5eb0bec 100644\n--- a/test.cpp\n+++ b/test.cpp\n@@ -1 +1,2"
+            b" @@\n+Hello World\n",
+            {
+                "message": b"Random commit message\nDifferential Diff: PHID-DIFF-testABcd12",
+                "user": b"test <test@mozilla.com>",
+            },
+        ),
+        # Add try_task_config
+        (
+            "add",
+            str(try_task).encode(),
+        ),
+        # Commit try_task_config
+        (
+            "commit",
+            {
+                "message": "try_task_config for code-review\n"
+                "Differential Diff: PHID-DIFF-testABcd12",
+                "user": "libmozevent <release-mgmt-analysis@mozilla.com>",
+            },
+        ),
+        # Push to try
+        "tip",
+        (
+            "push",
+            {
+                "dest": b"ssh://hg.mozilla.org/try",
+                "force": True,
+                "rev": b"test_tip",
+                "ssh": f'ssh -o StrictHostKeyChecking="no" -o User="reviewbot@mozilla.com" -o IdentityFile="{ssh_key_path}"'.encode(),
+            },
+        ),
+    ]
+
+    # Reset settings for following tests
+    mock_config.mercurial_cache = None
+    mock_config.ssh_key = None

--- a/bot/tests/test_analysis.py
+++ b/bot/tests/test_analysis.py
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from code_review_bot.config import RepositoryConf
+from code_review_bot.revisions import Revision
+
+
+def test_revision(mock_autoland_task, mock_phabricator, mock_hgmo):
+    """
+    Validate the creation of a Revision in analysis context
+    using Phabricator webhook payload
+    """
+
+    with mock_phabricator as api:
+        revision = Revision.from_phabricator_trigger(
+            revision_phid="PHID-DREV-1234",
+            transactions=[
+                "PHID-XACT-aaaa",
+            ],
+            phabricator=api,
+        )
+
+    assert revision.as_dict() == {
+        "base_changeset": "tip",
+        "base_repository": "https://hg.mozilla.org/mozilla-central",
+        "bugzilla_id": 1234567,
+        "diff_id": 42,
+        "diff_phid": "PHID-DIFF-test",
+        "has_clang_files": False,
+        "head_changeset": None,
+        "head_repository": None,
+        "id": 51,
+        "mercurial_revision": None,
+        "phid": "PHID-DREV-1234",
+        "repository": None,
+        "target_repository": "https://hg.mozilla.org/mozilla-central",
+        "title": "Static Analysis tests",
+        "url": "https://phabricator.test/D51",
+    }
+    assert revision.build_target_phid == "PHID-HMBT-test"
+    assert revision.phabricator_phid == "PHID-DREV-1234"
+    assert revision.base_repository_conf == RepositoryConf(
+        name="mozilla-central",
+        try_name="try",
+        url="https://hg.mozilla.org/mozilla-central",
+        try_url="ssh://hg.mozilla.org/try",
+        decision_env_prefix="GECKO",
+        ssh_user="reviewbot@mozilla.com",
+    )
+    assert revision.repository_try_name == "try"


### PR DESCRIPTION
Refs #2518 

This is the new code-review bot behaviour to support Phabricator webhook triggers, replacing the events system running on Heroku.

The revision & diffs are loaded using these environment variables:
-  `PHABRICATOR_OBJECT_PHID` which is the revision phid
- `PHABRICATOR_TRANSACTIONS` which is a json encoded list of Phabricator transactions, which contains the history of the revision at the time of the trigger

The bot must:
- retrieve the revision, repository, diff and Harbormaster target from Phabricator API
- clone the base repo at its tip
- load the stack of patches from Phabricator
- apply them on the clone
- push to try
- report state (or errors) on Phabricator
- report state (or errors) on Lando

The bot now depends on libmozevent, allowing the code port to be relatively minimal (no mercurial code, no Phabricator patch stack management).
But this means the bot needs to implement the high-level objects used by code-review-events to communicate with libmozevent (ie `PhabricatorBuild` to propagate state of a diff) and instantiate the various parts of events system (phabricator actions, mercurial repo & worker).

The CLI boot code is extended to support the new environment variable and run this new workflow (named `Analysis` here). In that mode, a `Revision` is instantiated using a dedicated method that:
1. load the revision from Phabricator
2. identify the repository against known configurations (to get try urls)
3. find the diff from Phabricator using provided transactions
4. find the Harbormaster build target (passing through buildable & build)

Once the `Revision` object is created, the workflow starts, running a new `start_analysis` method which will:
1. check the revision author is not blacklisted
2. check the mercurial cache is enabled
3. check the SSH key is available to push on try (from secrets)
4. Update phabricator state to Working
5. create the internal `RevisionBuild` which allows us to use libmozevent classes
6. instantiate libmozevent services:
   - `PhabricatorActions` to update the build state & fetch stack of patches
   - `Repository` & `MercurialWorker` to clone the repo & apply stack of patches, then push to try
7. Check the diff is public
8. Load stack of patches from Phabricator
9. Clone the repository
10. Apply the stack of patches & push to try when applying was successful
11. Publish outcome on Phabricator & Lando

We could work on followups to port subsystems directly into the bot, even removing the need for libmozevent (extras could be in libmozdata, especially for phabricator calls).