### PR TITLE
Update RevisionBuild state to provide required data to Lando

### DIFF
--- a/bot/code_review_bot/analysis.py
+++ b/bot/code_review_bot/analysis.py
@@ -28,6 +28,7 @@ class RevisionBuild(PhabricatorBuild):
 
         # Revision used by Phabricator updates
         # Direct output of Phabricator API (not the object passed here)
+        self.revision_id = revision.phabricator_id
         self.revision_url = None
         self.revision = None
 
@@ -45,7 +46,10 @@ class RevisionBuild(PhabricatorBuild):
         self.missing_base_revision = False
 
     def __str__(self):
-        return f"Phabricator Diff {self.diff_id}"
+        return f"Phabricator Revision {self.revision_id} - Diff {self.diff_id}"
+
+    def __repr__(self):
+        return str(self)
 
 
 def publish_analysis_phabricator(payload, phabricator_api):
@@ -138,8 +142,12 @@ def publish_analysis_phabricator(payload, phabricator_api):
 
 
 def publish_analysis_lando(payload, lando_warnings):
+    """
+    Publish result of patch application and push to try on Lando
+    """
     mode, build, extras = payload
-    logger.debug("Publishing a Lando build update", mode=mode, build=build)
+    assert isinstance(build, RevisionBuild), "Not a RevisionBuild"
+    logger.debug("Publishing a Lando build update", mode=mode, build=str(build))
 
     if mode == "fail:general":
         # Send general failure message to Lando

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -279,7 +279,8 @@ class Workflow:
             repositories={},
         )
 
-        while build.retries > 0:
+        # Try to update the state 5 consecutive time
+        for i in range(5):
             # Update the internal build state using Phabricator infos
             phabricator.update_state(build)
 


### PR DESCRIPTION
This PR fixes the bug encoutered when trying to push Lando updates upon Phabricator triggers ([example](https://firefox-ci-tc.services.mozilla.com/tasks/VXUCtq-qRLaSEFYFHKoLqg/runs/0/logs/public/logs/live.log))

The `phabricator.update_state` method was not triggered, thus not updating the `build.revision` dict using data from Phabricator, which was expected by the Lando publication code.

I was able to test this by running

```
export PHABRICATOR_OBJECT_PHID=PHID-DREV-yqqy3neexfvt4eiyppqn
export PHABRICATOR_OBJECT_TYPE=DREV
export PHABRICATOR_TRANSACTIONS='["PHID-XACT-DREV-y7wk6gi2ifoz6sp","PHID-XACT-DREV-oamyuv56fp3ud43","PHID-XACT-DREV-c2ezdtdzoynkrtx","PHID-XACT-DREV-b7ka37gfj277shk","PHID-XACT-DREV-3yasjftjia2w46s"]'
code-review-bot --conf=~/dev/mozilla/conf-dev.yml  --mercurial-repository=~/dev/mozilla/cache/
```
