### PR TITLE
Move all code_review_tools code into the bot

### DIFF
--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -21,9 +21,9 @@ from code_review_bot import AnalysisException, stats, taskcluster
 from code_review_bot.config import settings
 from code_review_bot.report import get_reporters
 from code_review_bot.revisions import Revision
+from code_review_bot.tools.libmozdata import setup as setup_libmozdata
+from code_review_bot.tools.log import init_logger
 from code_review_bot.workflow import Workflow
-from code_review_tools.libmozdata import setup as setup_libmozdata
-from code_review_tools.log import init_logger
 
 logger = structlog.get_logger(__name__)
 

--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -14,7 +14,7 @@ from code_review_bot.backend import BackendAPI
 from code_review_bot.report.base import Reporter
 from code_review_bot.tasks.clang_tidy_external import ExternalTidyIssue
 from code_review_bot.tasks.coverage import CoverageIssue
-from code_review_tools import treeherder
+from code_review_bot.tools import treeherder
 
 BUG_REPORT_URL = "https://bugzilla.mozilla.org/enter_bug.cgi?product=Developer+Infrastructure&component=Source+Code+Analysis&short_desc=[Automated+review]+THIS+IS+A+PLACEHOLDER&comment=**Phabricator+URL:**+https://phabricator.services.mozilla.com/...&format=__default__"
 

--- a/bot/code_review_bot/tools/libmozdata.py
+++ b/bot/code_review_bot/tools/libmozdata.py
@@ -1,0 +1,31 @@
+from importlib.metadata import version
+
+import structlog
+from libmozdata.config import Config, set_config
+
+logger = structlog.get_logger(__name__)
+
+
+class LocalConfig(Config):
+    """
+    Provide required configuration for libmozdata
+    using in-memory class instead of an INI file
+    """
+
+    def __init__(self, name, version):
+        self.user_agent = f"{name}/{version}"
+        logger.debug(f"User agent is {self.user_agent}")
+
+    def get(self, section, option, default=None, **kwargs):
+        if section == "User-Agent" and option == "name":
+            return self.user_agent
+
+        return default
+
+
+def setup(package_name):
+    # Get version for main package
+    package_version = version(package_name)
+
+    # Provide to custom libzmodata configuration
+    set_config(LocalConfig(package_name, package_version))

--- a/bot/code_review_bot/tools/log.py
+++ b/bot/code_review_bot/tools/log.py
@@ -1,0 +1,175 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import logging
+import logging.handlers
+import os
+import re
+
+import pkg_resources
+import sentry_sdk
+import structlog
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+root = logging.getLogger()
+
+# Found on https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+# 7-bit C1 ANSI sequences
+ANSI_ESCAPE = re.compile(
+    r"""
+    \x1B  # ESC
+    (?:   # 7-bit C1 Fe (except CSI)
+        [@-Z\\-_]
+    |     # or [ for CSI, followed by a control sequence
+        \[
+        [0-?]*  # Parameter bytes
+        [ -/]*  # Intermediate bytes
+        [@-~]   # Final byte
+    )
+""",
+    re.VERBOSE,
+)
+
+
+class AppNameFilter(logging.Filter):
+    def __init__(self, project_name, channel, *args, **kwargs):
+        self.project_name = project_name
+        self.channel = channel
+        super().__init__(*args, **kwargs)
+
+    def filter(self, record):
+        record.app_name = f"code-review/{self.channel}/{self.project_name}"
+        return True
+
+
+def setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT):
+    """
+    Setup papertrail account using taskcluster secrets
+    """
+
+    # Setup papertrail
+    papertrail = logging.handlers.SysLogHandler(
+        address=(PAPERTRAIL_HOST, int(PAPERTRAIL_PORT)),
+    )
+    formatter = logging.Formatter(
+        "%(app_name)s: %(asctime)s %(filename)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    papertrail.setLevel(logging.INFO)
+    papertrail.setFormatter(formatter)
+    # This filter is used to add the 'app_name' value to all logs to be formatted
+    papertrail.addFilter(AppNameFilter(project_name, channel))
+    root.addHandler(papertrail)
+
+
+def remove_color_codes(event, hint):
+    """
+    Remove ANSI color codes from a Sentry event before it gets published
+    """
+
+    def _remove(content):
+        try:
+            return ANSI_ESCAPE.sub("", content)
+        except Exception as e:
+            # Do not log here, rely on simple print
+            print(f"Failed to remove color code: {e}")
+            return content
+
+    # Remove from breadcrumb
+    breadcrumbs = event.get("breadcrumbs", {})
+    for value in breadcrumbs.get("values", []):
+        if "message" in value:
+            value["message"] = _remove(value["message"])
+
+    # Remove from log entry
+    logentry = event.get("logentry", {})
+    if "message" in logentry:
+        logentry["message"] = _remove(logentry["message"])
+
+    return event
+
+
+def setup_sentry(name, channel, dsn):
+    """
+    Setup sentry account using taskcluster secrets
+    """
+    # Detect environment
+    task_id = os.environ.get("TASK_ID")
+    if task_id is not None:
+        site = "taskcluster"
+    elif "DYNO" in os.environ:
+        site = "heroku"
+    else:
+        site = "unknown"
+
+    # This integration allows sentry to catch logs from logging and process them
+    # By default, the 'event_level' is set to ERROR, we are defining it to WARNING
+    sentry_logging = LoggingIntegration(
+        level=logging.INFO,  # Capture INFO and above as breadcrumbs
+        event_level=logging.WARNING,  # Send WARNINGs as events
+    )
+    # sentry_sdk will automatically retrieve the 'extra' attribute from logs and
+    # add contained values as Additional Data on the dashboard of the Sentry issue
+    sentry_sdk.init(
+        dsn=dsn,
+        integrations=[sentry_logging],
+        server_name=name,
+        environment=channel,
+        release=pkg_resources.get_distribution(f"code-review-{name}").version,
+        before_send=remove_color_codes,
+    )
+    sentry_sdk.set_tag("site", site)
+
+    if task_id is not None:
+        # Add a Taskcluster task id when available
+        # It will be shown in a new section called Task on the dashboard
+        sentry_sdk.set_context("task", {"task_id": task_id})
+
+
+def init_logger(
+    project_name,
+    channel=None,
+    level=logging.INFO,
+    PAPERTRAIL_HOST=None,
+    PAPERTRAIL_PORT=None,
+    SENTRY_DSN=None,
+):
+    if not channel:
+        channel = os.environ.get("APP_CHANNEL")
+
+    # Render extra information from structlog on default logging output
+    formatter = logging.Formatter(
+        "%(asctime)s.%(msecs)06d [%(levelname)-8s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(level)
+
+    # Log to papertrail
+    if channel and PAPERTRAIL_HOST and PAPERTRAIL_PORT:
+        setup_papertrail(project_name, channel, PAPERTRAIL_HOST, PAPERTRAIL_PORT)
+
+    # Log to sentry
+    if channel and SENTRY_DSN:
+        setup_sentry(project_name, channel, SENTRY_DSN)
+
+    # Setup structlog
+    processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.StackInfoRenderer(),
+        structlog.dev.set_exc_info,
+        structlog.dev.ConsoleRenderer(),
+    ]
+
+    structlog.configure(
+        processors=processors,
+        context_class=structlog.threadlocal.wrap_dict(dict),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )

--- a/bot/code_review_bot/tools/treeherder.py
+++ b/bot/code_review_bot/tools/treeherder.py
@@ -1,0 +1,18 @@
+from urllib.parse import urlencode
+
+JOBS_URL = "https://treeherder.mozilla.org/#/jobs"
+
+
+def get_job_url(repository, revision, task_id=None, run_id=None, **params):
+    """Build a Treeherder job url for a given Taskcluster task"""
+    assert isinstance(repository, str) and repository, "Missing repository"
+    assert isinstance(revision, str) and revision, "Missing revision"
+    assert "repo" not in params, "repo cannot be set in params"
+    assert "revision" not in params, "revision cannot be set in params"
+
+    params.update({"repo": repository, "revision": revision})
+
+    if task_id is not None and run_id is not None:
+        params["selectedTaskRun"] = f"{task_id}-{run_id}"
+
+    return f"{JOBS_URL}?{urlencode(params)}"

--- a/bot/docker/Dockerfile
+++ b/bot/docker/Dockerfile
@@ -1,14 +1,13 @@
 FROM python:3.13.2-slim
 
+# TODO: remove by switching to modern pyproject.toml
 RUN pip install setuptools==74.1.2 --disable-pip-version-check --no-cache-dir --quiet
-
-ADD tools /src/tools
-RUN cd /src/tools && python setup.py install
 
 ADD bot /src/bot
 RUN cd /src/bot && python setup.py install
 
 # Add mercurial & robustcheckout
-RUN /src/tools/docker/bootstrap-mercurial.sh
+COPY tools/docker/bootstrap-mercurial.sh /src/bot/docker
+RUN /src/bot/docker/bootstrap-mercurial.sh
 
 CMD ["code-review-bot"]

--- a/bot/requirements.txt
+++ b/bot/requirements.txt
@@ -1,6 +1,9 @@
--e ../tools #egg=code-review-tools
+aiohttp<4
 influxdb==5.3.2
+libmozdata==0.2.9
 libmozevent==1.1.30
 python-hglib==2.6.2
 pyyaml==6.0.2
+sentry-sdk==2.22.0
 setuptools==75.8.0
+structlog==25.1.0

--- a/bot/tests/test_tools.py
+++ b/bot/tests/test_tools.py
@@ -5,7 +5,7 @@
 import pytest
 from taskcluster.helper import TaskclusterConfig
 
-from code_review_tools.log import remove_color_codes
+from code_review_bot.tools.log import remove_color_codes
 
 
 def test_taskcluster_service():


### PR DESCRIPTION
This MR copies the required source code from `code_review_tools` into a new bot module `code_review_bot.tools`.

The `code_review_tools` module is no longer needed, meaning the bot sub-project only has external open-source dependencies.

After this MR, we'll be able to delete all the source code from both events & tools sub-projects whenever required.