### PR TITLE
Remove code_review_tools from CI usage

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -107,7 +107,6 @@ tasks:
                   - -lxce
                   - "apt-get update -q && apt-get install -q -y --no-install-recommends git &&
                     git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b checks &&
-                    cd /src/tools && ${pip_install} . &&
                     cd /src/bot && ${pip_install} . && ${pip_install} -r requirements-dev.txt &&
                     pytest -v"
               metadata:
@@ -200,7 +199,6 @@ tasks:
                   - sh
                   - -lxce
                   - "git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b checks &&
-                    cd /src/tools && ${pip_install} . &&
                     cd /src/backend && ${pip_install} . && ${pip_install} -r requirements-dev.txt &&
                     ./ci/setup_postgres.sh &&
                     ./manage.py test && ./manage.py makemigrations --check --noinput --dry-run -v 3"
@@ -313,7 +311,6 @@ tasks:
                   - sh
                   - -lxce
                   - "git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b checks &&
-                    cd /src/tools && ${pip_install} . &&
                     cd /src/integration && ${pip_install} -r requirements.txt -r requirements-dev.txt &&
                     pytest -v"
               metadata:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,3 @@
--e ../tools #egg=code-review-tools
 Django==5.1.6
 django-cors-headers==4.7.0
 django-environ==0.12.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,7 +7,9 @@ drf-yasg==1.21.8
 gunicorn==23.0.0
 parsepatch==0.1.3
 psycopg2-binary==2.9.10
+sentry-sdk==2.22.0
 setuptools==75.8.0
 sqlparse==0.5.3
+taskcluster==81.0.2
 tqdm==4.67.1
 whitenoise==6.9.0

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,2 +1,4 @@
 MozPhab==1.8.1
 pyyaml==6.0.2
+structlog==25.1.0
+taskcluster==81.0.2


### PR DESCRIPTION
The `code_review_tools` sub-project is now only necessary in the events codebase.

This MR removes:
- tools requirement in the backend: there were no more usage of the lib in the code base
- installation in CI for:
   - bot unit tests
   - backend unit tests
   - integration hook unit tests

Next step are to remove events CI, then events & tools codebase