### PR TITLE
Fix repo early usage in the backend new endpoints

### DIFF
--- a/backend/code_review_backend/issues/api.py
+++ b/backend/code_review_backend/issues/api.py
@@ -434,6 +434,7 @@ class IssueList(generics.ListAPIView):
         try:
             repo = Repository.objects.get(slug=repo_slug)
         except Repository.DoesNotExist:
+            repo = None
             errors["repo_slug"].append(
                 "invalid repo_slug path argument - No repository match this slug"
             )


### PR DESCRIPTION
I found another bug due to the Repository list being almost empty on testing backend (`mozilla-central` was missing).

So when the bot requests a list of existing issues for the repo, it triggered a 500 ([exception in the bot here](https://firefox-ci-tc.services.mozilla.com/tasks/BbdEDHrQRPSxJPXx2-aqYg/runs/0/logs/live/public/logs/live.log))

The `repo` value was not initialized when no `Repository` was found, leading to the crash.

Now the API returns a proper 400 when there are no matching repo, and the testing instance returns an empty list as I created the `mozilla-central` repo in the admin