### PR TITLE
Publish task links for analysis & publication workflows

### DIFF
--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -202,6 +202,16 @@ class Settings:
     def cleanup(self):
         shutil.rmtree(self.hgmo_cache)
 
+    @property
+    def taskcluster_url(self):
+        """
+        Build the current taskcluster task url
+        """
+        if self.taskcluster is None or self.taskcluster.local:
+            return
+
+        return f"https://firefox-ci-tc.services.mozilla.com/tasks/{self.taskcluster.task_id}"
+
 
 # Shared instance
 settings = Settings()

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -96,6 +96,13 @@ class Workflow:
 
         # Set the Phabricator build as running
         self.update_status(revision, state=BuildState.Work)
+        if settings.taskcluster_url:
+            self.publish_link(
+                revision,
+                slug="publication",
+                name="Publication task",
+                url=settings.taskcluster_url,
+            )
 
         # Analyze revision patch to get files/lines data
         revision.analyze_patch()
@@ -245,6 +252,13 @@ class Workflow:
 
         # Set the Phabricator build as running
         self.update_status(revision, state=BuildState.Work)
+        if settings.taskcluster_url:
+            self.publish_link(
+                revision,
+                slug="analysis",
+                name="Analysis task",
+                url=settings.taskcluster_url,
+            )
 
         # Initialize Phabricator build using revision
         build = RevisionBuild(revision)
@@ -671,3 +685,27 @@ class Workflow:
 
         self.phabricator.update_build_target(revision.build_target_phid, state)
         logger.info("Updated HarborMaster status", state=state, revision=revision)
+
+    def publish_link(self, revision: Revision, slug: str, name: str, url: str):
+        """
+        Publish a link as an Harbormaster artifact
+        """
+        if not revision.build_target_phid:
+            logger.info(
+                "No build target found, skipping HarborMaster link creation",
+                slug=slug,
+                url=url,
+            )
+            return
+
+        if not self.update_build:
+            logger.info(
+                "Update build disabled, skipping HarborMaster link creation ",
+                slug=slug,
+                url=url,
+            )
+            return
+
+        self.phabricator.create_harbormaster_uri(
+            revision.build_target_phid, slug, name, url
+        )

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -688,7 +688,7 @@ class Workflow:
 
     def publish_link(self, revision: Revision, slug: str, name: str, url: str):
         """
-        Publish a link as an Harbormaster artifact
+        Publish a link as a HarborMaster artifact
         """
         if not revision.build_target_phid:
             logger.info(
@@ -700,7 +700,7 @@ class Workflow:
 
         if not self.update_build:
             logger.info(
-                "Update build disabled, skipping HarborMaster link creation ",
+                "Update build disabled, skipping HarborMaster link creation",
                 slug=slug,
                 url=url,
             )

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -137,6 +137,7 @@ def test_on_production(mock_config, mock_repositories):
     assert mock_config.app_channel == "test"
     assert mock_config.taskcluster.local is True
     assert mock_config.on_production is False
+    assert mock_config.taskcluster_url is None
 
     # Taskcluster env + testing is not production
     os.environ["TASK_ID"] = "testingTask"
@@ -146,6 +147,10 @@ def test_on_production(mock_config, mock_repositories):
     assert testing.app_channel == "testing"
     assert testing.taskcluster.local is False
     assert testing.on_production is False
+    assert (
+        testing.taskcluster_url
+        == "https://firefox-ci-tc.services.mozilla.com/tasks/testingTask"
+    )
 
     # Taskcluster env + production is production
     os.environ["TASK_ID"] = "prodTask"
@@ -155,6 +160,10 @@ def test_on_production(mock_config, mock_repositories):
     assert testing.app_channel == "production"
     assert testing.taskcluster.local is False
     assert testing.on_production is True
+    assert (
+        testing.taskcluster_url
+        == "https://firefox-ci-tc.services.mozilla.com/tasks/prodTask"
+    )
 
 
 def test_before_after(mock_taskcluster_config, mock_workflow, mock_task, mock_revision):


### PR DESCRIPTION
This publishes 2 more links on the Harbormaster build, towards both Taskcluster tasks (analysis & publication stages).