### PR TITLE
Use a generic env variable instead of MC/Autoland ones

### DIFF
--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -48,6 +48,13 @@ class InvalidTrigger(Exception):
     """
 
 
+class InvalidRepository(Exception):
+    """
+    Raised when the bot has been started on a build task from
+    an unsupported repository
+    """
+
+
 class Level(enum.Enum):
     # A critical issue breaks CI and must always be reported
     Error = "error"

--- a/bot/code_review_bot/__init__.py
+++ b/bot/code_review_bot/__init__.py
@@ -41,6 +41,13 @@ class AnalysisException(Exception):
         super().__init__(message)
 
 
+class InvalidTrigger(Exception):
+    """
+    Raised when the bot has been started with an invalid trigger
+    Main reason is a gecko-level-3 task not being a build (cron, ...)
+    """
+
+
 class Level(enum.Enum):
     # A critical issue breaks CI and must always be reported
     Error = "error"

--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -17,7 +17,13 @@ from libmozdata.phabricator import (
     UnitResultState,
 )
 
-from code_review_bot import AnalysisException, InvalidTrigger, stats, taskcluster
+from code_review_bot import (
+    AnalysisException,
+    InvalidRepository,
+    InvalidTrigger,
+    stats,
+    taskcluster,
+)
 from code_review_bot.config import settings
 from code_review_bot.report import get_reporters
 from code_review_bot.revisions import Revision
@@ -174,6 +180,11 @@ def main():
         logger.info("Early stop analysis due to invalid trigger", error=str(e))
 
         # Stop cleanly as we just want to ignore that case
+        return 0
+    except InvalidRepository as e:
+        logger.warning("Early stop analysis due to invalid repository", error=str(e))
+
+        # Stop cleanly as we just want to ignore that case, but report on sentry through warning
         return 0
     except Exception as e:
         # Report revision loading failure on production only

--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -155,13 +155,9 @@ def main():
 
     # Load unique revision
     try:
-        if settings.autoland_group_id:
+        if settings.generic_group_id:
             revision = Revision.from_decision_task(
-                queue_service.task(settings.autoland_group_id), phabricator_api
-            )
-        elif settings.mozilla_central_group_id:
-            revision = Revision.from_decision_task(
-                queue_service.task(settings.mozilla_central_group_id), phabricator_api
+                queue_service.task(settings.generic_group_id), phabricator_api
             )
         elif settings.phabricator_build_target:
             revision = Revision.from_phabricator_trigger(
@@ -202,10 +198,8 @@ def main():
         task_failures_ignored=taskcluster.secrets["task_failures_ignored"],
     )
     try:
-        if settings.autoland_group_id:
-            w.ingest_revision(revision, settings.autoland_group_id)
-        elif settings.mozilla_central_group_id:
-            w.ingest_revision(revision, settings.mozilla_central_group_id)
+        if settings.generic_group_id:
+            w.ingest_revision(revision, settings.generic_group_id)
         elif settings.phabricator_build_target:
             w.start_analysis(revision)
         else:

--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -17,7 +17,7 @@ from libmozdata.phabricator import (
     UnitResultState,
 )
 
-from code_review_bot import AnalysisException, stats, taskcluster
+from code_review_bot import AnalysisException, InvalidTrigger, stats, taskcluster
 from code_review_bot.config import settings
 from code_review_bot.report import get_reporters
 from code_review_bot.revisions import Revision
@@ -170,6 +170,11 @@ def main():
                 queue_service.task(settings.try_group_id),
                 phabricator_api,
             )
+    except InvalidTrigger as e:
+        logger.info("Early stop analysis due to invalid trigger", error=str(e))
+
+        # Stop cleanly as we just want to ignore that case
+        return 0
     except Exception as e:
         # Report revision loading failure on production only
         # On testing or dev instances, we can use different Phabricator

--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -45,8 +45,7 @@ class Settings:
         self.taskcluster = None
         self.try_task_id = None
         self.try_group_id = None
-        self.autoland_group_id = None
-        self.mozilla_central_group_id = None
+        self.generic_group_id = None
         self.phabricator_build_target = None
         self.repositories = []
         self.decision_env_prefixes = []
@@ -84,10 +83,8 @@ class Settings:
         if "TRY_TASK_ID" in os.environ and "TRY_TASK_GROUP_ID" in os.environ:
             self.try_task_id = os.environ["TRY_TASK_ID"]
             self.try_group_id = os.environ["TRY_TASK_GROUP_ID"]
-        elif "AUTOLAND_TASK_GROUP_ID" in os.environ:
-            self.autoland_group_id = os.environ["AUTOLAND_TASK_GROUP_ID"]
-        elif "MOZILLA_CENTRAL_TASK_GROUP_ID" in os.environ:
-            self.mozilla_central_group_id = os.environ["MOZILLA_CENTRAL_TASK_GROUP_ID"]
+        elif "GENERIC_TASK_GROUP_ID" in os.environ:
+            self.generic_group_id = os.environ["GENERIC_TASK_GROUP_ID"]
         elif "PHABRICATOR_BUILD_TARGET" in os.environ:
             # Setup trigger mode using Phabricator information
             self.phabricator_build_target = os.environ["PHABRICATOR_BUILD_TARGET"]

--- a/bot/code_review_bot/revisions.py
+++ b/bot/code_review_bot/revisions.py
@@ -142,6 +142,14 @@ class Revision:
         ]
 
     @property
+    def from_autoland(self):
+        return self.head_repository == REPO_AUTOLAND
+
+    @property
+    def from_mozilla_central(self):
+        return self.head_repository == REPO_MOZILLA_CENTRAL
+
+    @property
     def before_after_feature(self):
         """
         Randomly run the before/after feature depending on a configured ratio.


### PR DESCRIPTION
Refs #2773

This PR replaces usage of `MOZILLA_CENTRAL_TASK_GROUP_ID` and `AUTOLAND_TASK_GROUP_ID` by `GENERIC_TASK_GROUP_ID`.

The existing code already [looks up the head repository](https://github.com/mozilla/code-review/blob/master/bot/code_review_bot/revisions.py#L291-L314) and is generic, supporting both Autoland & MC.

This assumes that the hook is triggered directly with a unique `GENERIC_TASK_GROUP_ID` environment variable.