### PR TITLE
Import libmozevent mercurial

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -107,6 +107,7 @@ tasks:
                   - -lxce
                   - "apt-get update -q && apt-get install -q -y --no-install-recommends git &&
                     git clone --quiet ${repository} /src && cd /src && git checkout ${head_rev} -b checks &&
+                    /src/tools/docker/bootstrap-mercurial.sh &&
                     cd /src/bot && ${pip_install} . && ${pip_install} -r requirements-dev.txt &&
                     pytest -v"
               metadata:

--- a/bot/code_review_bot/mercurial.py
+++ b/bot/code_review_bot/mercurial.py
@@ -88,8 +88,16 @@ def hg_run(cmd):
 
 
 def robust_checkout(
-    repo_url, checkout_dir, sharebase_dir, revision, repo_upstream_url=None
+    repo_url,
+    checkout_dir,
+    sharebase_dir,
+    revision=None,
+    branch=None,
+    repo_upstream_url=None,
 ):
+    if not ((revision is not None) ^ (branch is not None)):
+        raise Exception("Set revision XOR branch")
+
     cmd = hglib.util.cmdbuilder(
         "robustcheckout",
         repo_url,
@@ -97,6 +105,7 @@ def robust_checkout(
         purge=True,
         sharebase=sharebase_dir,
         revision=revision,
+        branch=branch,
         upstream=repo_upstream_url,
     )
     hg_run(cmd)
@@ -163,7 +172,7 @@ class Repository:
         if self.checkout_mode == "batch":
             batch_checkout(self.url, self.dir, b"tip", self.batch_size)
         elif self.checkout_mode == "robust":
-            robust_checkout(self.url, self.dir, self.share_base_dir, b"tip")
+            robust_checkout(self.url, self.dir, self.share_base_dir, branch=b"tip")
         else:
             hglib.clone(self.url, self.dir)
         logger.info("Full checkout finished")

--- a/bot/code_review_bot/mercurial.py
+++ b/bot/code_review_bot/mercurial.py
@@ -2,12 +2,38 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import asyncio
+import atexit
+import enum
 import fcntl
+import io
+import json
 import os
+import tempfile
 import time
+from datetime import datetime
 
 import hglib
+import requests
+import rs_parsepatch
 import structlog
+from libmozdata.phabricator import PhabricatorPatch
+from libmozevent.phabricator import PhabricatorBuild
+from libmozevent.utils import batch_checkout
+
+logger = structlog.get_logger(__name__)
+
+TREEHERDER_URL = "https://treeherder.mozilla.org/#/jobs?repo={}&revision={}"
+DEFAULT_AUTHOR = "libmozevent <release-mgmt-analysis@mozilla.com>"
+# On build failure, check try status until available every 5 minutes and up to 24h
+TRY_STATUS_URL = "https://treestatus.mozilla-releng.net/trees/try"
+TRY_STATUS_DELAY = 5 * 60
+TRY_STATUS_MAX_WAIT = 24 * 60 * 60
+# Number of allowed retries on an unexpected push fail
+MAX_PUSH_RETRIES = 4
+# Wait successive exponential delays: 6sec, 36sec, 3.6min, 21.6min
+PUSH_RETRY_EXPONENTIAL_DELAY = 6
+
 
 logger = structlog.get_logger(__name__)
 
@@ -69,3 +95,502 @@ def robust_checkout(
         upstream=repo_upstream_url,
     )
     hg_run(cmd)
+
+
+class TryMode(enum.Enum):
+    json = "json"
+    syntax = "syntax"
+
+
+class Repository:
+    """
+    A Mercurial repository with its try server credentials
+    """
+
+    def __init__(self, config, cache_root):
+        assert isinstance(config, dict)
+        self.name = config["name"]
+        self.url = config["url"]
+        self.dir = os.path.join(cache_root, config["name"])
+        self.checkout_mode = config.get("checkout", "batch")
+        self.batch_size = config.get("batch_size", 10000)
+        self.try_url = config["try_url"]
+        self.try_mode = TryMode(config.get("try_mode", "json"))
+        self.try_syntax = config.get("try_syntax")
+        self.try_name = config.get("try_name", "try")
+        self.default_revision = config.get("default_revision", "tip")
+
+        # Apply patches to the latest revision when `True`.
+        self.use_latest_revision = config.get("use_latest_revision", False)
+
+        if self.try_mode == TryMode.syntax:
+            assert self.try_syntax, "Missing try syntax"
+        self._repo = None
+
+        # Write ssh key from secret
+        _, self.ssh_key_path = tempfile.mkstemp(suffix=".key")
+        with open(self.ssh_key_path, "w") as f:
+            f.write(config["ssh_key"])
+
+        # Build ssh conf
+        conf = {
+            "StrictHostKeyChecking": "no",
+            "User": config["ssh_user"],
+            "IdentityFile": self.ssh_key_path,
+        }
+        self.ssh_conf = "ssh {}".format(
+            " ".join(f'-o {k}="{v}"' for k, v in conf.items())
+        ).encode("utf-8")
+
+        # Remove key when finished
+        atexit.register(self.end_of_life)
+
+    def __str__(self):
+        return self.name
+
+    def end_of_life(self):
+        os.unlink(self.ssh_key_path)
+        logger.info("Removed ssh key")
+
+    def clone(self):
+        logger.info("Checking out tip", repo=self.url, mode=self.checkout_mode)
+        if self.checkout_mode == "batch":
+            batch_checkout(self.url, self.dir, b"tip", self.batch_size)
+        elif self.checkout_mode == "robust":
+            robust_checkout(self.url, self.dir, b"tip")
+        else:
+            hglib.clone(self.url, self.dir)
+        logger.info("Full checkout finished")
+
+        # Setup repo in main process
+        self.repo.setcbout(lambda msg: logger.info("Mercurial", stdout=msg))
+        self.repo.setcberr(lambda msg: logger.info("Mercurial", stderr=msg))
+
+    @property
+    def repo(self):
+        """
+        Get the repo instance, in case it's None re-open it
+        """
+        if self._repo is None or self._repo.server is None:
+            logger.info(f"Mercurial open {self.dir}")
+            self._repo = hglib.open(self.dir)
+
+        return self._repo
+
+    def has_revision(self, revision):
+        """
+        Check if a revision is available on this Mercurial repo
+        """
+        if not revision:
+            return False
+        try:
+            self.repo.identify(revision)
+            return True
+        except hglib.error.CommandError:
+            return False
+
+    def get_base_identifier(self, needed_stack: list[PhabricatorPatch]) -> str:
+        """Return the base identifier to apply patches against."""
+        if self.use_latest_revision:
+            # Use `tip` when `use_latest_revision` is `True`.
+            return "tip"
+
+        # Otherwise use the base/parent revision of first revision in the stack.
+        return needed_stack[0].base_revision
+
+    def apply_build(self, build):
+        """
+        Apply a stack of patches to mercurial repo
+        and commit them one by one
+        """
+        assert isinstance(build, PhabricatorBuild)
+        assert len(build.stack) > 0, "No patches to apply"
+        assert all(map(lambda p: isinstance(p, PhabricatorPatch), build.stack))
+
+        # Find the first unknown base revision
+        needed_stack = []
+        for patch in reversed(build.stack):
+            needed_stack.insert(0, patch)
+
+            # Stop as soon as a base revision is available
+            if self.has_revision(patch.base_revision):
+                logger.info(f"Stopping at revision {patch.base_revision}")
+                break
+
+        if not needed_stack:
+            logger.info("All the patches are already applied")
+            return
+
+        hg_base = self.get_base_identifier(needed_stack)
+
+        # When base revision is missing, update to default revision
+        build.base_revision = hg_base
+        # TODO: Re-enable base revision identification after https://github.com/mozilla/libmozevent/issues/110.
+        build.missing_base_revision = False  # not self.has_revision(hg_base)
+        if build.missing_base_revision:
+            logger.warning(
+                "Missing base revision from Phabricator",
+                revision=hg_base,
+                fallback=self.default_revision,
+            )
+            hg_base = self.default_revision
+        hg_base = self.default_revision
+
+        # Store the actual base revision we used
+        build.actual_base_revision = hg_base
+
+        # Update the repo to base revision
+        try:
+            logger.info(f"Updating repo to revision {hg_base}")
+            self.repo.update(rev=hg_base, clean=True)
+
+            # See if the repo is clean
+            repo_status = self.repo.status(
+                modified=True, added=True, removed=True, deleted=True
+            )
+            if len(repo_status) != 0:
+                logger.warn(
+                    "Repo is dirty! Let's clean it first.",
+                    revision=hg_base,
+                    repo=self.name,
+                    repo_status=repo_status,
+                )
+                # Clean the repo - This is a workaround for Bug 1720302
+                self.repo.update(rev="null", clean=True)
+                # Redo the update to the correct revision
+                self.repo.update(rev=hg_base, clean=True)
+
+        except hglib.error.CommandError:
+            raise Exception(f"Failed to update to revision {hg_base}")
+
+        # In this case revision is `hg_base`
+        logger.info("Updated repo", revision=hg_base, repo=self.name)
+
+        def get_author(commit):
+            """Helper to build a mercurial author from Phabricator data"""
+            author = commit.get("author")
+            if author is None:
+                return DEFAULT_AUTHOR
+            if author["name"] and author["email"]:
+                # Build clean version without quotes
+                return f"{author['name']} <{author['email']}>"
+            return author["raw"]
+
+        for patch in needed_stack:
+            if patch.commits:
+                # Use the first commit only
+                commit = patch.commits[0]
+                message = "{}\n".format(commit["message"])
+                user = get_author(commit)
+            else:
+                # We should always have some commits here
+                logger.warning("Missing commit on patch", id=patch.id)
+                message = ""
+                user = DEFAULT_AUTHOR
+            message += f"Differential Diff: {patch.phid}"
+
+            logger.info("Applying patch", phid=patch.phid, message=message)
+            try:
+                self.repo.import_(
+                    patches=io.BytesIO(patch.patch.encode("utf-8")),
+                    message=message.encode("utf-8"),
+                    user=user.encode("utf-8"),
+                )
+            except Exception as e:
+                logger.info(
+                    f"Failed to apply patch: {e}",
+                    phid=patch.phid,
+                    exc_info=True,
+                )
+                raise
+
+    def add_try_commit(self, build):
+        """
+        Build and commit the file configuring try
+        * always try_task_config.json
+        * MC payload in json mode
+        * custom simpler payload on syntax mode
+        """
+        path = os.path.join(self.dir, "try_task_config.json")
+        if self.try_mode == TryMode.json:
+            config = {
+                "version": 2,
+                "parameters": {
+                    "target_tasks_method": "codereview",
+                    "optimize_target_tasks": True,
+                    "phabricator_diff": build.target_phid,
+                },
+            }
+            diff_phid = build.stack[-1].phid
+
+            if build.revision_url:
+                message = f"try_task_config for {build.revision_url}"
+            else:
+                message = "try_task_config for code-review"
+            message += f"\nDifferential Diff: {diff_phid}"
+
+        elif self.try_mode == TryMode.syntax:
+            config = {
+                "version": 2,
+                "parameters": {
+                    "code-review": {"phabricator-build-target": build.target_phid}
+                },
+            }
+            message = f"try: {self.try_syntax}"
+            if build.revision_url is not None:
+                message += f"\nPhabricator Revision: {build.revision_url}"
+
+        else:
+            raise Exception("Unsupported try mode")
+
+        # Write content as json and commit it
+        with open(path, "w") as f:
+            json.dump(config, f, sort_keys=True, indent=4)
+        self.repo.add(path.encode("utf-8"))
+        self.repo.commit(message=message, user=DEFAULT_AUTHOR)
+
+    def push_to_try(self):
+        """
+        Push the current tip on remote try repository
+        """
+        tip = self.repo.tip()
+        logger.info("Pushing patches to try", rev=tip.node)
+        self.repo.push(
+            dest=self.try_url.encode("utf-8"),
+            rev=tip.node,
+            ssh=self.ssh_conf,
+            force=True,
+        )
+        return tip
+
+    def clean(self):
+        """
+        Steps to clean the mercurial repo
+        """
+        logger.info("Remove uncommitted changes")
+        self.repo.revert(self.dir.encode("utf-8"), all=True)
+
+        logger.info("Remove all mercurial drafts")
+        try:
+            cmd = hglib.util.cmdbuilder(
+                b"strip", rev=b"roots(outgoing())", force=True, backup=False
+            )
+            self.repo.rawcommand(cmd)
+        except hglib.error.CommandError as e:
+            if b"abort: empty revision set" not in e.err:
+                raise
+
+        logger.info("Pull updates from remote repo")
+        self.repo.pull()
+
+
+class MercurialWorker:
+    """
+    Mercurial worker maintaining several local clones
+    """
+
+    ELIGIBLE_RETRY_ERRORS = [
+        error.lower()
+        for error in [
+            "push failed on remote",
+            "stream ended unexpectedly",
+            "error: EOF occurred in violation of protocol",
+        ]
+    ]
+
+    def __init__(
+        self,
+        queue_name,
+        queue_phabricator,
+        repositories,
+        skippable_files=[],
+    ):
+        assert all(map(lambda r: isinstance(r, Repository), repositories.values()))
+        self.queue_name = queue_name
+        self.queue_phabricator = queue_phabricator
+        self.repositories = repositories
+        self.skippable_files = skippable_files
+
+    def register(self, bus):
+        self.bus = bus
+        self.bus.add_queue(self.queue_name)
+
+    async def run(self):
+        # First clone all repositories
+        for repo in self.repositories.values():
+            logger.info(f"Cloning repo {repo}")
+            repo.clone()
+
+        # Wait for phabricator diffs to apply
+        while True:
+            build = await self.bus.receive(self.queue_name)
+            assert isinstance(build, PhabricatorBuild)
+
+            # Find the repository from the diff and trigger the build on it
+            repository = self.repositories.get(build.repo_phid)
+            if repository is not None:
+                result = await self.handle_build(repository, build)
+                if result:
+                    await self.bus.send(self.queue_phabricator, result)
+
+            else:
+                logger.error(
+                    "Unsupported repository",
+                    repo=build.repo_phid,
+                    build=build,
+                    exc_info=True,
+                )
+
+    def is_commit_skippable(self, build):
+        def get_files_touched_in_diff(rawdiff):
+            patched = []
+            for parsed_diff in rs_parsepatch.get_diffs(rawdiff):
+                # filename is sometimes of format 'test.txt  Tue Feb 05 17:23:40 2019 +0100'
+                # fix after https://github.com/mozilla/rust-parsepatch/issues/61
+                if "filename" in parsed_diff:
+                    filename = parsed_diff["filename"].split(" ")[0]
+                    patched.append(filename)
+            return patched
+
+        return any(
+            patched_file in self.skippable_files
+            for rev in build.stack
+            for patched_file in get_files_touched_in_diff(rev.patch)
+        )
+
+    async def wait_try_available(self):
+        """
+        Wait until try status is "open"
+        On each failure, wait TRY_STATUS_DELAY before retrying up to TRY_STATUS_MAX_WAIT
+        """
+
+        def get_status():
+            try:
+                resp = requests.get(TRY_STATUS_URL)
+                resp.raise_for_status()
+                data = resp.json()
+            except Exception as e:
+                logger.warning(f"An error occurred retrieving try status: {e}")
+            else:
+                return data.get("result", {}).get("status")
+
+        start = datetime.utcnow()
+        while status := get_status() != "open":
+            if (datetime.utcnow() - start).seconds >= TRY_STATUS_MAX_WAIT:
+                logger.error(
+                    f"Try tree status still closed after {TRY_STATUS_MAX_WAIT} seconds, skipping",
+                    exc_info=True,
+                )
+                break
+            logger.warning(
+                f"Try tree is not actually open (status: {status}), waiting {TRY_STATUS_DELAY} seconds before retrying"
+            )
+            await asyncio.sleep(TRY_STATUS_DELAY)
+
+    def is_eligible_for_retry(self, error):
+        """
+        Given a Mercurial error message, if it's an error likely due to a
+        temporary connection problem, consider it as eligible for retry.
+        """
+        error = error.lower()
+        return any(
+            eligible_message in error for eligible_message in self.ELIGIBLE_RETRY_ERRORS
+        )
+
+    async def handle_build(self, repository, build):
+        """
+        Try to load and apply a diff on local clone
+        If successful, push to try and send a treeherder link
+        In case of an unexpected push failure, retry up to MAX_PUSH_RETRIES
+        times by putting the build task back in the queue
+
+        If the build fail, send a unit result with a warning message
+        """
+        assert isinstance(repository, Repository)
+        start = time.time()
+
+        if build.retries > MAX_PUSH_RETRIES:
+            error_log = "Max number of retries has been reached pushing the build to try repository"
+            logger.warn("Mercurial error on diff", error=error_log, build=build)
+            return (
+                "fail:mercurial",
+                build,
+                {"message": error_log, "duration": time.time() - start},
+            )
+
+        if build.retries:
+            logger.warning(
+                "Trying to apply build's diff after a remote push error "
+                f"[{build.retries}/{MAX_PUSH_RETRIES}]"
+            )
+
+        try:
+            # Start by cleaning the repo
+            repository.clean()
+
+            # First apply patches on local repo
+            repository.apply_build(build)
+
+            # Check Eligibility: some commits don't need to be pushed to try.
+            if self.is_commit_skippable(build):
+                logger.info("This patch series is ineligible for automated try push")
+                return (
+                    "fail:ineligible",
+                    build,
+                    {
+                        "message": "Modified files match skippable internal configuration files",
+                        "duration": time.time() - start,
+                    },
+                )
+
+            # Configure the try task
+            repository.add_try_commit(build)
+
+            # Then push that stack on try
+            tip = repository.push_to_try()
+            logger.info("Diff has been pushed !")
+
+            # Publish Treeherder link
+            uri = TREEHERDER_URL.format(repository.try_name, tip.node.decode("utf-8"))
+        except hglib.error.CommandError as e:
+            # Format nicely the error log
+            error_log = e.err
+            if isinstance(error_log, bytes):
+                error_log = error_log.decode("utf-8")
+
+            if self.is_eligible_for_retry(error_log):
+                build.retries += 1
+                # Ensure try is opened
+                await self.wait_try_available()
+                # Wait an exponential time before retrying the build
+                delay = PUSH_RETRY_EXPONENTIAL_DELAY**build.retries
+                logger.info(
+                    f"An error occurred pushing the build to try, retrying after {delay}s"
+                )
+                await asyncio.sleep(delay)
+                # Put the build task back in the queue
+                await self.bus.send(self.queue_name, build)
+                return
+
+            logger.warn(
+                "Mercurial error on diff", error=error_log, args=e.args, build=build
+            )
+            return (
+                "fail:mercurial",
+                build,
+                {"message": error_log, "duration": time.time() - start},
+            )
+
+        except Exception as e:
+            logger.warn("Failed to process diff", error=e, build=build)
+            return (
+                "fail:general",
+                build,
+                {"message": str(e), "duration": time.time() - start},
+            )
+
+        return (
+            "success",
+            build,
+            {"treeherder_url": uri, "revision": tip.node.decode("utf-8")},
+        )

--- a/bot/code_review_bot/mercurial.py
+++ b/bot/code_review_bot/mercurial.py
@@ -416,7 +416,8 @@ class MercurialWorker:
         in case of try server errors
         """
         while build.retries <= MAX_PUSH_RETRIES:
-            start = datetime.utcnow()
+            start = time.time()
+
             if build.retries:
                 logger.warning(
                     "Trying to apply build's diff after a remote push error "
@@ -446,7 +447,6 @@ class MercurialWorker:
                     f"An error occurred pushing the build to try, retrying after {delay}s"
                 )
                 time.sleep(delay)
-                return
 
     def is_commit_skippable(self, build):
         def get_files_touched_in_diff(rawdiff):

--- a/bot/code_review_bot/mercurial.py
+++ b/bot/code_review_bot/mercurial.py
@@ -23,9 +23,9 @@ from libmozevent.utils import batch_checkout
 logger = structlog.get_logger(__name__)
 
 TREEHERDER_URL = "https://treeherder.mozilla.org/#/jobs?repo={}&revision={}"
-DEFAULT_AUTHOR = "libmozevent <release-mgmt-analysis@mozilla.com>"
+DEFAULT_AUTHOR = "code review bot <release-mgmt-analysis@mozilla.com>"
 # On build failure, check try status until available every 5 minutes and up to 24h
-TRY_STATUS_URL = "https://treestatus.mozilla-releng.net/trees/try"
+TRY_STATUS_URL = "https://treestatus.prod.lando.prod.cloudops.mozgcp.net/trees/try"
 TRY_STATUS_DELAY = 5 * 60
 TRY_STATUS_MAX_WAIT = 24 * 60 * 60
 # Number of allowed retries on an unexpected push fail

--- a/bot/code_review_bot/mercurial.py
+++ b/bot/code_review_bot/mercurial.py
@@ -112,6 +112,7 @@ class Repository:
         self.name = config["name"]
         self.url = config["url"]
         self.dir = os.path.join(cache_root, config["name"])
+        self.share_base_dir = os.path.join(cache_root, f"{config['name']}-shared")
         self.checkout_mode = config.get("checkout", "batch")
         self.batch_size = config.get("batch_size", 10000)
         self.try_url = config["try_url"]
@@ -157,7 +158,7 @@ class Repository:
         if self.checkout_mode == "batch":
             batch_checkout(self.url, self.dir, b"tip", self.batch_size)
         elif self.checkout_mode == "robust":
-            robust_checkout(self.url, self.dir, b"tip")
+            robust_checkout(self.url, self.dir, self.share_base_dir, b"tip")
         else:
             hglib.clone(self.url, self.dir)
         logger.info("Full checkout finished")

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import asyncio
 import time
 from datetime import datetime, timedelta
 from itertools import groupby
@@ -292,13 +291,7 @@ class Workflow:
             cache_root=settings.mercurial_cache,
         )
 
-        worker = MercurialWorker(
-            # We are not using the mercurial workflow
-            # so we can initialize with empty data here
-            queue_name=None,
-            queue_phabricator=None,
-            repositories={},
-        )
+        worker = MercurialWorker()
 
         # Try to update the state 5 consecutive time
         for i in range(5):
@@ -337,9 +330,8 @@ class Workflow:
         # We'll clone the required repository
         repository.clone()
 
-        # Apply the stack of patches using asynchronous method
-        # that runs directly in that process
-        output = asyncio.run(worker.handle_build(repository, build))
+        # Apply the stack of patches and push to try
+        output = worker.handle_build(repository, build)
 
         # Update final state using worker output
         if self.update_build:

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -9,7 +9,6 @@ from itertools import groupby
 
 import structlog
 from libmozdata.phabricator import BuildState, PhabricatorAPI
-from libmozevent.mercurial import MercurialWorker, Repository
 from libmozevent.phabricator import PhabricatorActions, PhabricatorBuildState
 from taskcluster.utils import stringDate
 
@@ -21,7 +20,7 @@ from code_review_bot.analysis import (
 )
 from code_review_bot.backend import BackendAPI
 from code_review_bot.config import settings
-from code_review_bot.mercurial import robust_checkout
+from code_review_bot.mercurial import MercurialWorker, Repository, robust_checkout
 from code_review_bot.report.debug import DebugReporter
 from code_review_bot.revisions import Revision
 from code_review_bot.tasks.base import AnalysisTask, BaseTask, NoticeTask

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -291,8 +291,6 @@ class Workflow:
             cache_root=settings.mercurial_cache,
         )
 
-        worker = MercurialWorker()
-
         # Try to update the state 5 consecutive time
         for i in range(5):
             # Update the internal build state using Phabricator infos
@@ -331,7 +329,8 @@ class Workflow:
         repository.clone()
 
         # Apply the stack of patches and push to try
-        output = worker.handle_build(repository, build)
+        worker = MercurialWorker()
+        output = worker.run(repository, build)
 
         # Update final state using worker output
         if self.update_build:

--- a/bot/requirements-dev.txt
+++ b/bot/requirements-dev.txt
@@ -1,6 +1,5 @@
 pre-commit==4.2.0
 pytest==8.3.5
-pytest-asyncio==1.0.0
 pytest-responses==0.5.1
 pytest-structlog==1.1
 responses==0.25.7

--- a/bot/requirements-dev.txt
+++ b/bot/requirements-dev.txt
@@ -1,5 +1,6 @@
 pre-commit==4.2.0
 pytest==8.3.5
+pytest-asyncio==1.0.0
 pytest-responses==0.5.1
 pytest-structlog==1.1
 responses==0.25.7

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -272,7 +272,7 @@ def mock_phabricator(mock_config):
     with open(config_file.name, "w") as f:
         custom_conf = ConfigParser()
         custom_conf.add_section("User-Agent")
-        custom_conf.set("User-Agent", "name", "libmozdata")
+        custom_conf.set("User-Agent", "name", "code-review-bot/1.0")
         custom_conf.write(f)
         f.seek(0)
 
@@ -993,7 +993,7 @@ class MockBuild(PhabricatorBuild):
         with open(config_file.name, "w") as f:
             custom_conf = ConfigParser()
             custom_conf.add_section("User-Agent")
-            custom_conf.set("User-Agent", "name", "libmozdata")
+            custom_conf.set("User-Agent", "name", "code-review-bot/1.0")
             custom_conf.write(f)
             f.seek(0)
         from libmozdata import config

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -13,12 +13,14 @@ import uuid
 from collections import defaultdict, namedtuple
 from configparser import ConfigParser
 from contextlib import contextmanager
+from unittest.mock import MagicMock
 
 import hglib
 import pytest
 import responses
 from libmozdata.phabricator import PhabricatorAPI
 from libmozevent.phabricator import (
+    PhabricatorActions,
     PhabricatorBuild,
     PhabricatorBuildState,
 )
@@ -26,6 +28,7 @@ from libmozevent.phabricator import (
 from code_review_bot import Level, stats
 from code_review_bot.backend import BackendAPI
 from code_review_bot.config import GetAppUserAgent, settings
+from code_review_bot.mercurial import Repository
 from code_review_bot.tasks.clang_tidy import ClangTidyIssue, ClangTidyTask
 from code_review_bot.tasks.default import DefaultTask
 
@@ -1006,3 +1009,232 @@ class MockBuild(PhabricatorBuild):
         self.state = PhabricatorBuildState.Public
         self.revision_url = None
         self.retries = 0
+
+
+def build_repository(tmpdir, name):
+    """
+    Mock a local mercurial repo
+    """
+    # Init empty repo
+    repo_dir = str(tmpdir.mkdir(name).realpath())
+    hglib.init(repo_dir)
+
+    # Add default pull in Mercurial config
+    hgrc = tmpdir.join(name, ".hg", "hgrc")
+    hgrc.write(f"[paths]\ndefault = {repo_dir}")
+
+    # Open repo with config
+    repo = hglib.open(repo_dir)
+
+    # Commit a file on central
+    readme = tmpdir.join(name, "README.md")
+    readme.write("Hello World")
+    repo.add(str(readme.realpath()).encode("utf-8"))
+    repo.branch(name=b"central", force=True)
+    repo.commit(message=b"Readme", user="test")
+
+    # Mock push to avoid reaching try server
+    repo.push = MagicMock(return_value=True)
+
+    return repo
+
+
+@pytest.fixture
+def mock_mc(tmpdir):
+    """
+    Mock a Mozilla Central repository
+    """
+    config = {
+        "name": "mozilla-central",
+        "ssh_user": "john@doe.com",
+        "ssh_key": "privateSSHkey",
+        "url": "http://mozilla-central",
+        "try_url": "http://mozilla-central/try",
+        "batch_size": 100,
+    }
+    repo = Repository(config, tmpdir.realpath())
+    repo._repo = build_repository(tmpdir, "mozilla-central")
+    repo.clone = MagicMock(side_effect=lambda: True)
+    return repo
+
+
+@pytest.fixture
+def mock_nss(tmpdir):
+    """
+    Mock an NSS repository
+    """
+    config = {
+        "name": "nss",
+        "ssh_user": "john@doe.com",
+        "ssh_key": "privateSSHkey",
+        "url": "http://nss",
+        "try_url": "http://nss/try",
+        "try_mode": "syntax",
+        "try_syntax": "-a -b XXX -c YYY",
+        "batch_size": 100,
+    }
+    repo = Repository(config, tmpdir.realpath())
+    repo._repo = build_repository(tmpdir, "nss")
+    repo.clone = MagicMock(side_effect=lambda: True)
+    return repo
+
+
+@pytest.fixture
+@contextmanager
+def PhabricatorMock():
+    """
+    Mock phabricator authentication process
+    """
+    json_headers = {"Content-Type": "application/json"}
+
+    def _response(name):
+        path = os.path.join(MOCK_DIR, "phabricator", f"{name}.json")
+        assert os.path.exists(path), f"Missing mock {path}"
+        return open(path).read()
+
+    def _phab_params(request):
+        # What a weird way to send parameters
+        return json.loads(urllib.parse.parse_qs(request.body)["params"][0])
+
+    def _diff_search(request):
+        params = _phab_params(request)
+        assert "constraints" in params
+        if "revisionPHIDs" in params["constraints"]:
+            # Search from revision
+            mock_name = "search-{}".format(params["constraints"]["revisionPHIDs"][0])
+        elif "ids" in params["constraints"]:
+            # Search from diff IDs
+            diffs = "-".join(map(str, params["constraints"]["ids"]))
+            mock_name = f"search-{diffs}"
+        elif "phids" in params["constraints"]:
+            # Search from diff PHIDs
+            diffs = "-".join(params["constraints"]["phids"])
+            mock_name = f"search-{diffs}"
+        else:
+            raise Exception(f"Unsupported diff mock {params}")
+        return (200, json_headers, _response(mock_name))
+
+    def _diff_raw(request):
+        params = _phab_params(request)
+        assert "diffID" in params
+        return (200, json_headers, _response("raw-{}".format(params["diffID"])))
+
+    def _edges(request):
+        params = _phab_params(request)
+        assert "sourcePHIDs" in params
+        return (
+            200,
+            json_headers,
+            _response("edges-{}".format(params["sourcePHIDs"][0])),
+        )
+
+    def _create_artifact(request):
+        params = _phab_params(request)
+        assert "buildTargetPHID" in params
+        return (
+            200,
+            json_headers,
+            _response("artifact-{}".format(params["buildTargetPHID"])),
+        )
+
+    def _send_message(request):
+        params = _phab_params(request)
+        assert "buildTargetPHID" in params
+        name = "message-{}-{}".format(params["buildTargetPHID"], params["type"])
+        if params["unit"]:
+            name += "-unit"
+        if params["lint"]:
+            name += "-lint"
+        return (200, json_headers, _response(name))
+
+    def _project_search(request):
+        params = _phab_params(request)
+        assert "constraints" in params
+        assert "slugs" in params["constraints"]
+        return (200, json_headers, _response("projects"))
+
+    def _revision_search(request):
+        params = _phab_params(request)
+        assert "constraints" in params
+        assert "ids" in params["constraints"]
+        assert "attachments" in params
+        assert "projects" in params["attachments"]
+        assert "reviewers" in params["attachments"]
+        assert params["attachments"]["projects"]
+        assert params["attachments"]["reviewers"]
+        mock_name = "revision-search-{}".format(params["constraints"]["ids"][0])
+        return (200, json_headers, _response(mock_name))
+
+    def _user_search(request):
+        params = _phab_params(request)
+        assert "constraints" in params
+        assert "phids" in params["constraints"]
+        mock_name = "user-search-{}".format(params["constraints"]["phids"][0])
+        return (200, json_headers, _response(mock_name))
+
+    with responses.RequestsMock(assert_all_requests_are_fired=False) as resp:
+        resp.add(
+            responses.POST,
+            "http://phabricator.test/api/user.whoami",
+            body=_response("auth"),
+            content_type="application/json",
+        )
+
+        resp.add_callback(
+            responses.POST, "http://phabricator.test/api/edge.search", callback=_edges
+        )
+
+        resp.add_callback(
+            responses.POST,
+            "http://phabricator.test/api/differential.diff.search",
+            callback=_diff_search,
+        )
+
+        resp.add_callback(
+            responses.POST,
+            "http://phabricator.test/api/differential.getrawdiff",
+            callback=_diff_raw,
+        )
+
+        resp.add_callback(
+            responses.POST,
+            "http://phabricator.test/api/harbormaster.createartifact",
+            callback=_create_artifact,
+        )
+
+        resp.add_callback(
+            responses.POST,
+            "http://phabricator.test/api/harbormaster.sendmessage",
+            callback=_send_message,
+        )
+
+        resp.add(
+            responses.POST,
+            "http://phabricator.test/api/diffusion.repository.search",
+            body=_response("repositories"),
+            content_type="application/json",
+        )
+
+        resp.add_callback(
+            responses.POST,
+            "http://phabricator.test/api/project.search",
+            callback=_project_search,
+        )
+
+        resp.add_callback(
+            responses.POST,
+            "http://phabricator.test/api/differential.revision.search",
+            callback=_revision_search,
+        )
+
+        resp.add_callback(
+            responses.POST,
+            "http://phabricator.test/api/user.search",
+            callback=_user_search,
+        )
+
+        actions = PhabricatorActions(
+            url="http://phabricator.test/api/", api_key="deadbeef"
+        )
+        actions.mocks = resp  # used to assert in tests on callbacks
+        yield actions

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -1088,7 +1088,7 @@ def PhabricatorMock():
     json_headers = {"Content-Type": "application/json"}
 
     def _response(name):
-        path = os.path.join(MOCK_DIR, "phabricator", f"{name}.json")
+        path = os.path.join(MOCK_DIR, f"phabricator_{name}.json")
         assert os.path.exists(path), f"Missing mock {path}"
         return open(path).read()
 

--- a/bot/tests/mocks/phabricator_edges-PHID-DREV-666.json
+++ b/bot/tests/mocks/phabricator_edges-PHID-DREV-666.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "data": [
+    ],
+    "cursor": {
+      "limit": 100,
+      "after": null,
+      "before": null
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_edges-PHID-DREV-badutf8.json
+++ b/bot/tests/mocks/phabricator_edges-PHID-DREV-badutf8.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "data": [
+    ],
+    "cursor": {
+      "limit": 100,
+      "after": null,
+      "before": null
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_edges-PHID-DREV-deadbeef.json
+++ b/bot/tests/mocks/phabricator_edges-PHID-DREV-deadbeef.json
@@ -1,0 +1,18 @@
+{
+  "result": {
+    "data": [
+      {
+        "sourcePHID": "PHID-DREV-deadbeef",
+        "edgeType": "revision.parent",
+        "destinationPHID": "PHID-DREV-deadbeefParent"
+      }
+    ],
+    "cursor": {
+      "limit": 100,
+      "after": null,
+      "before": null
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_edges-PHID-DREV-deadbeefParent.json
+++ b/bot/tests/mocks/phabricator_edges-PHID-DREV-deadbeefParent.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "data": [
+    ],
+    "cursor": {
+      "limit": 100,
+      "after": null,
+      "before": null
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_edges-PHID-DREV-solo.json
+++ b/bot/tests/mocks/phabricator_edges-PHID-DREV-solo.json
@@ -1,0 +1,13 @@
+{
+  "result": {
+    "data": [
+    ],
+    "cursor": {
+      "limit": 100,
+      "after": null,
+      "before": null
+    }
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_projects.json
+++ b/bot/tests/mocks/phabricator_projects.json
@@ -1,0 +1,55 @@
+{
+	"result": {
+		"data": [{
+			"id": 21,
+			"type": "PROJ",
+			"phid": "PHID-PROJ-wkydohdk6pajyfn2llkb",
+			"fields": {
+				"name": "secure-revision",
+				"slug": "secure-revision",
+				"subtype": "default",
+				"milestone": null,
+				"depth": 0,
+				"parent": null,
+				"icon": {
+					"key": "policy",
+					"name": "Policy",
+					"icon": "fa-lock"
+				},
+				"color": {
+					"key": "blue",
+					"name": "Blue"
+				},
+				"spacePHID": null,
+				"dateCreated": 1519855816,
+				"dateModified": 1559859172,
+				"policy": {
+					"view": "users",
+					"edit": "admin",
+					"join": "admin"
+				},
+				"description": "The revision contains sensitive information and email should not be sent in the clear."
+			},
+			"attachments": {}
+		}],
+		"maps": {
+			"slugMap": {
+				"secure-revision": {
+					"slug": "secure-revision",
+					"projectPHID": "PHID-PROJ-wkydohdk6pajyfn2llkb"
+				}
+			}
+		},
+		"query": {
+			"queryKey": null
+		},
+		"cursor": {
+			"limit": 100,
+			"after": null,
+			"before": null,
+			"order": null
+		}
+	},
+	"error_code": null,
+	"error_info": null
+}

--- a/bot/tests/mocks/phabricator_raw-1233.json
+++ b/bot/tests/mocks/phabricator_raw-1233.json
@@ -1,0 +1,5 @@
+{
+  "result": "diff -r 000000000000 test.txt\n--- /dev/null Thu Jan 01 00:00:00 1970 +0000\n+++ b/test.txt  Tue Feb 05 17:23:40 2019 +0100\n@@ -0,0 +1,1 @@\n+First Line\n",
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_raw-1234.json
+++ b/bot/tests/mocks/phabricator_raw-1234.json
@@ -1,0 +1,5 @@
+{
+  "result": "diff -r b675fb77aad5 test.txt\n--- a/test.txt  Tue Feb 05 17:24:38 2019 +0100\n+++ b/test.txt  Tue Feb 05 17:24:50 2019 +0100\n@@ -1,1 +1,2 @@\n First Line\n+Second Line\n",
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_raw-555.json
+++ b/bot/tests/mocks/phabricator_raw-555.json
@@ -1,0 +1,5 @@
+{
+  "result": "diff -r 000000000000 test.txt\n--- /dev/null Thu Jan 01 00:00:00 1970 +0000\n+++ b/test.txt  Tue Feb 05 17:23:40 2019 +0100\n@@ -0,0 +1,1 @@\n+First Line\n",
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_raw-666.json
+++ b/bot/tests/mocks/phabricator_raw-666.json
@@ -1,0 +1,5 @@
+{
+  "result": "--- a/crash.txt Thu Jan 01 00:00:00 2019 +0000\n+++ b/crash.txt  Fri Feb 08 10:54:26 2019 +0000\n@@ -12,0 +12,1 @@\n+This cannot apply !\n\n",
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_raw-9876.json
+++ b/bot/tests/mocks/phabricator_raw-9876.json
@@ -1,0 +1,5 @@
+{
+  "result": "--- /dev/null  Thu Jan 01 00:00:00 1970 +0000\n+++ b/solo.txt  Fri Feb 08 10:54:26 2019 +0000\n@@ -0,0 +1,1 @@\n+Solo PATCH\n\n",
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/mocks/phabricator_repositories.json
+++ b/bot/tests/mocks/phabricator_repositories.json
@@ -1,0 +1,74 @@
+{
+    "error_code": null,
+    "error_info": null,
+    "result": {
+        "cursor": {
+            "after": null,
+            "before": null,
+            "limit": 100,
+            "order": null
+        },
+        "data": [
+            {
+                "attachments": {},
+                "fields": {
+                    "almanacServicePHID": null,
+                    "callsign": "MOZILLACENTRAL",
+                    "dateCreated": 1539455983,
+                    "dateModified": 1543603513,
+                    "isImporting": false,
+                    "name": "mozilla-central",
+                    "policy": {
+                        "diffusion.push": "users",
+                        "edit": "admin",
+                        "view": "public"
+                    },
+                    "refRules": {
+                        "fetchRules": [],
+                        "permanentRefRules": [],
+                        "trackRules": []
+                    },
+                    "shortName": "mozilla-central",
+                    "spacePHID": null,
+                    "status": "active",
+                    "vcs": "hg"
+                },
+                "id": 16,
+                "phid": "PHID-REPO-mc",
+                "type": "REPO"
+            },
+            {
+                "attachments": {},
+                "fields": {
+                    "almanacServicePHID": null,
+                    "callsign": "NSS",
+                    "dateCreated": 1539106756,
+                    "dateModified": 1543603469,
+                    "isImporting": false,
+                    "name": "nss",
+                    "policy": {
+                        "diffusion.push": "users",
+                        "edit": "admin",
+                        "view": "public"
+                    },
+                    "refRules": {
+                        "fetchRules": [],
+                        "permanentRefRules": [],
+                        "trackRules": []
+                    },
+                    "shortName": "nss",
+                    "spacePHID": null,
+                    "status": "active",
+                    "vcs": "hg"
+                },
+                "id": 15,
+                "phid": "PHID-REPO-nss",
+                "type": "REPO"
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        }
+    }
+}

--- a/bot/tests/mocks/phabricator_search-PHID-DIFF-666.json
+++ b/bot/tests/mocks/phabricator_search-PHID-DIFF-666.json
@@ -1,0 +1,53 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 666,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-666",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-666",
+                    "authorPHID": "PHID-USER-666",
+                    "repositoryPHID": "PHID-REPO-666",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "missing"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                  "commits": {
+                    "commits": [
+                      {
+                        "message": "This patch has no real base and will crash libmozevent"
+                      }
+                    ]
+                  }
+                }
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}
+

--- a/bot/tests/mocks/phabricator_search-PHID-DIFF-badutf8.json
+++ b/bot/tests/mocks/phabricator_search-PHID-DIFF-badutf8.json
@@ -1,0 +1,59 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 555,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-badutf8",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-badutf8",
+                    "authorPHID": "PHID-USER-badutf8",
+                    "repositoryPHID": "PHID-REPO-badutf8",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "missing"
+                        }
+                    ],
+                    "dateCreated": 0,
+                    "dateModified": 1,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                  "commits": {
+                    "commits": [
+                      {
+                        "message": "This patch has an author with utf8 chars",
+                        "author": {
+                          "name": "Andr\u00e9 XXXX",
+                          "email": "andre.xxxx@allizom.org",
+                          "raw": "\"Andr\u00e9 XXXX\" <andre.xxxx@allizom.org>",
+                          "epoch": 1566386156
+                        }
+                      }
+                    ]
+                  }
+                }
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}
+

--- a/bot/tests/mocks/phabricator_search-PHID-DIFF-solo.json
+++ b/bot/tests/mocks/phabricator_search-PHID-DIFF-solo.json
@@ -1,0 +1,53 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 456,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-solo",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-zzzzz",
+                    "authorPHID": "PHID-USER-xxxxx",
+                    "repositoryPHID": "PHID-REPO-aaaaaa",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "coffeedeadbeef123456789"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                  "commits": {
+                    "commits": [
+                      {
+                        "message": "A nice human readable commit message"
+                      }
+                    ]
+                  }
+                }
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}
+

--- a/bot/tests/mocks/phabricator_search-PHID-DIFF-test123.json
+++ b/bot/tests/mocks/phabricator_search-PHID-DIFF-test123.json
@@ -1,0 +1,58 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 456,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-test123",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-zzzzz",
+                    "authorPHID": "PHID-USER-xxxxx",
+                    "repositoryPHID": "PHID-REPO-aaaaaa",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "coffeedeadbeef123456789"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                  "commits": {
+                    "commits": [
+                      {
+                        "message": "Bug XXX - A second commit message",
+                        "author": {
+                          "name": "John Doe",
+                          "email": "john@allizom.org",
+                          "raw": "\"John Doe\" <john@allizom.org>"
+                        }
+                      }
+                    ]
+                  }
+                }
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}
+

--- a/bot/tests/mocks/phabricator_search-PHID-DIFF-xxxx.json
+++ b/bot/tests/mocks/phabricator_search-PHID-DIFF-xxxx.json
@@ -1,0 +1,58 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 123,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-xxxx",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-zzzzz",
+                    "authorPHID": "PHID-USER-xxxxx",
+                    "repositoryPHID": "PHID-REPO-aaaaaa",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "coffeedeadbeef123456789"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {
+                  "commits": {
+                    "commits": [
+                      {
+                        "message": "Bug XXX - A first commit message",
+                        "author": {
+                          "name": "randomUsername",
+                          "email": "",
+                          "raw": "randomUsername <random>"
+                        }
+                      }
+                    ]
+                  }
+                }
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}
+

--- a/bot/tests/mocks/phabricator_search-PHID-DREV-deadbeefParent.json
+++ b/bot/tests/mocks/phabricator_search-PHID-DREV-deadbeefParent.json
@@ -1,0 +1,45 @@
+{
+    "result": {
+        "data": [
+            {
+                "id": 1233,
+                "type": "DIFF",
+                "phid": "PHID-DIFF-xxxx",
+                "fields": {
+                    "revisionPHID": "PHID-DREV-zzzzz",
+                    "authorPHID": "PHID-USER-xxxxx",
+                    "repositoryPHID": "PHID-REPO-aaaaaa",
+                    "refs": [
+                        {
+                            "type": "branch",
+                            "name": "default"
+                        },
+                        {
+                            "type": "base",
+                            "identifier": "coffeedeadbeef123456789"
+                        }
+                    ],
+                    "dateCreated": 1510251135,
+                    "dateModified": 1510251138,
+                    "policy": {
+                        "view": "public"
+                    }
+                },
+                "attachments": {}
+            }
+        ],
+        "maps": {},
+        "query": {
+            "queryKey": null
+        },
+        "cursor": {
+            "limit": 100,
+            "after": null,
+            "before": null,
+            "order": null
+        }
+    },
+    "error_code": null,
+    "error_info": null
+}
+

--- a/bot/tests/test_analysis.py
+++ b/bot/tests/test_analysis.py
@@ -5,9 +5,9 @@
 import json
 import tempfile
 
-from libmozevent import utils
 from libmozevent.phabricator import PhabricatorActions
 
+from code_review_bot import mercurial
 from code_review_bot.config import RepositoryConf
 from code_review_bot.revisions import Revision
 
@@ -77,7 +77,7 @@ def test_workflow(
     def mock_hgrun(cmd):
         hgrun_calls.append(cmd)
 
-    monkeypatch.setattr(utils, "hg_run", mock_hgrun)
+    monkeypatch.setattr(mercurial, "hg_run", mock_hgrun)
 
     # Build never expires otherwise the analysis stops early
     monkeypatch.setattr(PhabricatorActions, "is_expired_build", lambda _, build: False)
@@ -107,7 +107,7 @@ def test_workflow(
             "robustcheckout",
             b"--purge",
             f"--sharebase={tmpdir}/mozilla-central-shared".encode(),
-            b"--branch=tip",
+            b"--revision=tip",
             b"--",
             "https://hg.mozilla.org/mozilla-central",
             repo_path,

--- a/bot/tests/test_analysis.py
+++ b/bot/tests/test_analysis.py
@@ -107,7 +107,7 @@ def test_workflow(
             "robustcheckout",
             b"--purge",
             f"--sharebase={tmpdir}/mozilla-central-shared".encode(),
-            b"--revision=tip",
+            b"--branch=tip",
             b"--",
             "https://hg.mozilla.org/mozilla-central",
             repo_path,
@@ -198,7 +198,7 @@ def test_workflow(
             {
                 "message": "try_task_config for https://phabricator.test/D51\n"
                 "Differential Diff: PHID-DIFF-testABcd12",
-                "user": "libmozevent <release-mgmt-analysis@mozilla.com>",
+                "user": "code review bot <release-mgmt-analysis@mozilla.com>",
             },
         ),
         # Push to try

--- a/bot/tests/test_mercurial.py
+++ b/bot/tests/test_mercurial.py
@@ -602,7 +602,6 @@ def test_crash_utf8_author(PhabricatorMock, mock_mc):
     assert details["revision"] == mock_mc.repo.tip().node.decode("utf-8")
 
 
-@responses.activate
 def test_unexpected_push_failure(PhabricatorMock, mock_mc):
     """
     When a fail occurs while pushing the file configuring try
@@ -660,7 +659,6 @@ def test_unexpected_push_failure(PhabricatorMock, mock_mc):
     ]
 
 
-@responses.activate
 def test_push_failure_max_retries(PhabricatorMock, mock_mc, monkeypatch):
     """
     When a fail occurs while pushing the file configuring try
@@ -722,7 +720,6 @@ def test_push_failure_max_retries(PhabricatorMock, mock_mc, monkeypatch):
     assert sleep_history == [2, 4]
 
 
-@responses.activate
 def test_push_closed_try(PhabricatorMock, mock_mc, monkeypatch):
     """
     Detect when try tree is in a closed state and wait before it is opened to retry

--- a/bot/tests/test_mercurial.py
+++ b/bot/tests/test_mercurial.py
@@ -1,8 +1,25 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import asyncio
+import json
+import os.path
+from unittest.mock import MagicMock
+
+import hglib
+import pytest
+import responses
+from conftest import MockBuild
+from libmozdata.phabricator import PhabricatorPatch
+from libmozevent.bus import MessageBus
 
 from code_review_bot import mercurial
+
+MERCURIAL_FAILURE = """unable to find 'crash.txt' for patching
+(use '--prefix' to apply patch relative to the current directory)
+1 out of 1 hunks FAILED -- saving rejects to file crash.txt.rej
+abort: patch failed to apply
+"""
 
 
 class STDOutputMock:
@@ -62,3 +79,898 @@ def test_robustcheckout(monkeypatch):
         "https://hg.repo/try",
         "/tmp/checkout",
     ]
+
+
+@pytest.mark.asyncio
+async def test_push_to_try(PhabricatorMock, mock_mc):
+    """
+    Run mercurial worker on a single diff
+    with a push to try server
+    """
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    # Preload the build
+    diff = {
+        "phid": "PHID-DIFF-test123",
+        "revisionPHID": "PHID-DREV-deadbeef",
+        "id": 1234,
+        # Revision does not exist, will apply on tip
+        "baseRevision": "abcdef12345",
+    }
+    build = MockBuild(1234, "PHID-REPO-mc", 5678, "PHID-HMBT-deadbeef", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    # Get initial tip commit in repo
+    initial = mock_mc.repo.tip()
+
+    # The patched and config files should not exist at first
+    repo_dir = mock_mc.repo.root().decode("utf-8")
+    config = os.path.join(repo_dir, "try_task_config.json")
+    target = os.path.join(repo_dir, "test.txt")
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": mock_mc}
+    )
+    worker.register(bus)
+    assert len(worker.repositories) == 1
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+    task = asyncio.create_task(worker.run())
+
+    # Check the treeherder link was queued
+    mode, out_build, details = await bus.receive("phabricator")
+    tip = mock_mc.repo.tip()
+    assert mode == "success"
+    assert out_build == build
+    assert details[
+        "treeherder_url"
+    ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
+        tip.node.decode("utf-8")
+    )
+    assert details["revision"] == tip.node.decode("utf-8")
+    task.cancel()
+
+    # The target should have content now
+    assert os.path.exists(target)
+    assert open(target).read() == "First Line\nSecond Line\n"
+
+    # Check the try_task_config file
+    assert os.path.exists(config)
+    assert json.load(open(config)) == {
+        "version": 2,
+        "parameters": {
+            "target_tasks_method": "codereview",
+            "optimize_target_tasks": True,
+            "phabricator_diff": "PHID-HMBT-deadbeef",
+        },
+    }
+
+    # Get tip commit in repo
+    # It should be different from the initial one (patches + config have applied)
+    assert tip.node != initial.node
+
+    # Check all commits messages
+    assert [c.desc for c in mock_mc.repo.log()] == [
+        b"try_task_config for code-review\nDifferential Diff: PHID-DIFF-test123",
+        b"Bug XXX - A second commit message\nDifferential Diff: PHID-DIFF-test123",
+        b"Bug XXX - A first commit message\nDifferential Diff: PHID-DIFF-xxxx",
+        b"Readme",
+    ]
+
+    # Check all commits authors
+    assert [c.author for c in mock_mc.repo.log()] == [
+        b"libmozevent <release-mgmt-analysis@mozilla.com>",
+        b"John Doe <john@allizom.org>",
+        b"randomUsername <random>",
+        b"test",
+    ]
+
+    # Check the push to try has been called
+    # with tip commit
+    ssh_conf = f'ssh -o StrictHostKeyChecking="no" -o User="john@doe.com" -o IdentityFile="{mock_mc.ssh_key_path}"'
+    mock_mc.repo.push.assert_called_with(
+        dest=b"http://mozilla-central/try",
+        force=True,
+        rev=tip.node,
+        ssh=ssh_conf.encode("utf-8"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_push_to_try_existing_rev(PhabricatorMock, mock_mc):
+    """
+    Run mercurial worker on a single diff
+    with a push to try server
+    but applying on an existing revision
+    """
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+    repo_dir = mock_mc.repo.root().decode("utf-8")
+
+    def _readme(content):
+        # Make a commit on README.md in the repo
+        readme = os.path.join(repo_dir, "README.md")
+        with open(readme, "a") as f:
+            f.write(content)
+        _, rev = mock_mc.repo.commit(message=content.encode("utf-8"), user=b"test")
+        return rev
+
+    # Make two commits, the first one is our base
+    base = _readme("Local base for diffs")
+    extra = _readme("EXTRA")
+
+    # Preload the build
+    diff = {
+        "phid": "PHID-DIFF-solo",
+        "revisionPHID": "PHID-DREV-solo",
+        "id": 9876,
+        # Revision does not exist, will apply on tip
+        "baseRevision": base,
+    }
+    build = MockBuild(1234, "PHID-REPO-mc", 5678, "PHID-HMBT-deadbeef", diff)
+    build.revision_url = "http://phab.test/D1234"
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    # The patched and config files should not exist at first
+    target = os.path.join(repo_dir, "solo.txt")
+    config = os.path.join(repo_dir, "try_task_config.json")
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": mock_mc}
+    )
+    worker.register(bus)
+    assert len(worker.repositories) == 1
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+    task = asyncio.create_task(worker.run())
+
+    # Check the treeherder link was queued
+    mode, out_build, details = await bus.receive("phabricator")
+    tip = mock_mc.repo.tip()
+    assert mode == "success"
+    assert out_build == build
+    assert details[
+        "treeherder_url"
+    ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
+        tip.node.decode("utf-8")
+    )
+    assert details["revision"] == tip.node.decode("utf-8")
+    task.cancel()
+
+    # The target should have content now
+    assert os.path.exists(target)
+    assert open(target).read() == "Solo PATCH\n"
+
+    # Check the try_task_config file
+    assert os.path.exists(config)
+    assert json.load(open(config)) == {
+        "version": 2,
+        "parameters": {
+            "target_tasks_method": "codereview",
+            "optimize_target_tasks": True,
+            "phabricator_diff": "PHID-HMBT-deadbeef",
+        },
+    }
+
+    # Get tip commit in repo
+    # It should be different from the initial one (patches and config have applied)
+    assert tip.node != base
+    assert (
+        tip.desc
+        == b"""try_task_config for http://phab.test/D1234
+Differential Diff: PHID-DIFF-solo"""
+    )
+
+    # Check the push to try has been called
+    # with tip commit
+    ssh_conf = f'ssh -o StrictHostKeyChecking="no" -o User="john@doe.com" -o IdentityFile="{mock_mc.ssh_key_path}"'
+    mock_mc.repo.push.assert_called_with(
+        dest=b"http://mozilla-central/try",
+        force=True,
+        rev=tip.node,
+        ssh=ssh_conf.encode("utf-8"),
+    )
+
+    # Check the parent is the solo patch commit
+    parents = mock_mc.repo.parents(tip.node)
+    assert len(parents) == 1
+    parent = parents[0]
+    assert (
+        parent.desc
+        == b"A nice human readable commit message\nDifferential Diff: PHID-DIFF-solo"
+    )
+
+    # Check the grand parent is the base, not extra
+    great_parents = mock_mc.repo.parents(parent.node)
+    assert len(great_parents) == 1
+    # TODO: Re-enable base revision identification after https://github.com/mozilla/libmozevent/issues/110.
+    # great_parent = great_parents[0]
+    # assert great_parent.node == base
+
+    # Extra commit should not appear
+    assert parent.node != extra
+    # TODO: Re-enable base revision identification after https://github.com/mozilla/libmozevent/issues/110.
+    # assert great_parent.node != extra
+    # assert "EXTRA" not in open(os.path.join(repo_dir, "README.md")).read()
+
+
+@pytest.mark.asyncio
+async def test_dont_push_skippable_files_to_try(PhabricatorMock, mock_mc):
+    """
+    Run mercurial worker on a single diff
+    that skips the push to try server
+    """
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    # Preload the build
+    diff = {
+        "phid": "PHID-DIFF-test123",
+        "revisionPHID": "PHID-DREV-deadbeef",
+        "id": 1234,
+        # Revision does not exist, will apply on tip
+        "baseRevision": "abcdef12345",
+    }
+    build = MockBuild(1234, "PHID-REPO-mc", 5678, "PHID-HMBT-deadbeef", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    # Get initial tip commit in repo
+    initial = mock_mc.repo.tip()
+
+    # The patched and config files should not exist at first
+    repo_dir = mock_mc.repo.root().decode("utf-8")
+    config = os.path.join(repo_dir, "try_task_config.json")
+    target = os.path.join(repo_dir, "test.txt")
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    worker = mercurial.MercurialWorker(
+        "mercurial",
+        "phabricator",
+        repositories={"PHID-REPO-mc": mock_mc},
+        skippable_files=["test.txt"],
+    )
+    worker.register(bus)
+    assert len(worker.repositories) == 1
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+    task = asyncio.create_task(worker.run())
+
+    # Check the treeherder link was queued
+    mode, out_build, details = await bus.receive("phabricator")
+    tip = mock_mc.repo.tip()
+    assert mode == "fail:ineligible"
+    assert out_build == build
+    assert (
+        details["message"]
+        == "Modified files match skippable internal configuration files"
+    )
+    task.cancel()
+
+    # The target should have content now
+    assert os.path.exists(target)
+    assert open(target).read() == "First Line\nSecond Line\n"
+
+    # Get tip commit in repo
+    # It should be different from the initial one (patches + config have applied)
+    assert tip.node != initial.node
+
+    # Check all commits messages
+    assert [c.desc for c in mock_mc.repo.log()] == [
+        b"Bug XXX - A second commit message\nDifferential Diff: PHID-DIFF-test123",
+        b"Bug XXX - A first commit message\nDifferential Diff: PHID-DIFF-xxxx",
+        b"Readme",
+    ]
+
+    # Check all commits authors
+    assert [c.author for c in mock_mc.repo.log()] == [
+        b"John Doe <john@allizom.org>",
+        b"randomUsername <random>",
+        b"test",
+    ]
+
+    # Check the push to try has not been called
+    mock_mc.repo.push.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_treeherder_link(PhabricatorMock, mock_mc):
+    """
+    Run mercurial worker on a single diff
+    and check the treeherder link publication as an artifact
+    """
+    # Preload the build
+    diff = {
+        "phid": "PHID-DIFF-test123",
+        "revisionPHID": "PHID-DREV-deadbeef",
+        "id": 1234,
+        "baseRevision": "abcdef12345",
+    }
+    build = MockBuild(1234, "PHID-REPO-mc", 5678, "PHID-HMBT-somehash", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    # Get initial tip commit in repo
+    initial = mock_mc.repo.tip()
+
+    # The patched and config files should not exist at first
+    repo_dir = mock_mc.repo.root().decode("utf-8")
+    config = os.path.join(repo_dir, "try_task_config.json")
+    target = os.path.join(repo_dir, "test.txt")
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": mock_mc}
+    )
+    worker.register(bus)
+    assert len(worker.repositories) == 1
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+    task = asyncio.create_task(worker.run())
+
+    # Check the treeherder link was queued
+    mode, out_build, details = await bus.receive("phabricator")
+    tip = mock_mc.repo.tip()
+    assert mode == "success"
+    assert out_build == build
+    assert details[
+        "treeherder_url"
+    ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
+        tip.node.decode("utf-8")
+    )
+    assert details["revision"] == tip.node.decode("utf-8")
+    task.cancel()
+
+    # Tip should be updated
+    assert tip.node != initial.node
+
+
+@pytest.mark.asyncio
+async def test_failure_general(PhabricatorMock, mock_mc):
+    """
+    Run mercurial worker on a single diff
+    and check the treeherder link publication as an artifact
+    Use a Python common exception to trigger a broken build
+    """
+    diff = {
+        "phid": "PHID-DIFF-test123",
+        "id": 1234,
+        "baseRevision": None,
+        "revisionPHID": "PHID-DREV-deadbeef",
+    }
+    build = MockBuild(1234, "PHID-REPO-mc", 5678, "PHID-somehash", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    # Get initial tip commit in repo
+    initial = mock_mc.repo.tip()
+
+    # The patched and config files should not exist at first
+    repo_dir = mock_mc.repo.root().decode("utf-8")
+    config = os.path.join(repo_dir, "try_task_config.json")
+    target = os.path.join(repo_dir, "test.txt")
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    # Raise an exception during the workflow to trigger a broken build
+    def boom(*args):
+        raise Exception("Boom")
+
+    mock_mc.apply_build = boom
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": mock_mc}
+    )
+    worker.register(bus)
+    assert len(worker.repositories) == 1
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+    task = asyncio.create_task(worker.run())
+
+    # Check the unit result was published
+    mode, out_build, details = await bus.receive("phabricator")
+    assert mode == "fail:general"
+    assert out_build == build
+    assert details["duration"] > 0
+    assert details["message"] == "Boom"
+    task.cancel()
+
+    # Clone should not be modified
+    tip = mock_mc.repo.tip()
+    assert tip.node == initial.node
+
+
+@pytest.mark.asyncio
+async def test_failure_mercurial(PhabricatorMock, mock_mc):
+    """
+    Run mercurial worker on a single diff
+    and check the treeherder link publication as an artifact
+    Apply a bad mercurial patch to trigger a mercurial fail
+    """
+    diff = {
+        "revisionPHID": "PHID-DREV-666",
+        "baseRevision": "missing",
+        "phid": "PHID-DIFF-666",
+        "id": 666,
+    }
+    build = MockBuild(1234, "PHID-REPO-mc", 5678, "PHID-build-666", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    # Get initial tip commit in repo
+    initial = mock_mc.repo.tip()
+
+    # The patched and config files should not exist at first
+    repo_dir = mock_mc.repo.root().decode("utf-8")
+    config = os.path.join(repo_dir, "try_task_config.json")
+    target = os.path.join(repo_dir, "test.txt")
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": mock_mc}
+    )
+    worker.register(bus)
+    assert len(worker.repositories) == 1
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+    task = asyncio.create_task(worker.run())
+
+    # Check the treeherder link was queued
+    mode, out_build, details = await bus.receive("phabricator")
+    assert mode == "fail:mercurial"
+    assert out_build == build
+    assert details["duration"] > 0
+    assert details["message"] == MERCURIAL_FAILURE
+    task.cancel()
+
+    # Clone should not be modified
+    tip = mock_mc.repo.tip()
+    assert tip.node == initial.node
+
+
+@pytest.mark.asyncio
+async def test_push_to_try_nss(PhabricatorMock, mock_nss):
+    """
+    Run mercurial worker on a single diff
+    with a push to try server, but with NSS support (try syntax)
+    """
+    diff = {
+        "phid": "PHID-DIFF-test123",
+        "revisionPHID": "PHID-DREV-deadbeef",
+        "id": 1234,
+        # Revision does not exist, will apply on tip
+        "baseRevision": "abcdef12345",
+    }
+    build = MockBuild(1234, "PHID-REPO-nss", 5678, "PHID-HMBT-deadbeef", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    # Get initial tip commit in repo
+    initial = mock_nss.repo.tip()
+
+    # The patched and config files should not exist at first
+    repo_dir = mock_nss.repo.root().decode("utf-8")
+    config = os.path.join(repo_dir, "try_task_config.json")
+    target = os.path.join(repo_dir, "test.txt")
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-nss": mock_nss}
+    )
+    worker.register(bus)
+    assert len(worker.repositories) == 1
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+    task = asyncio.create_task(worker.run())
+
+    # Check the treeherder link was queued
+    mode, out_build, details = await bus.receive("phabricator")
+    tip = mock_nss.repo.tip()
+    assert mode == "success"
+    assert out_build == build
+    assert details[
+        "treeherder_url"
+    ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
+        tip.node.decode("utf-8")
+    )
+    assert details["revision"] == tip.node.decode("utf-8")
+    task.cancel()
+
+    # The target should have content now
+    assert os.path.exists(target)
+    assert open(target).read() == "First Line\nSecond Line\n"
+
+    # The config should have content now
+    assert os.path.exists(config)
+    assert json.load(open(config)) == {
+        "version": 2,
+        "parameters": {
+            "code-review": {"phabricator-build-target": "PHID-HMBT-deadbeef"}
+        },
+    }
+
+    # Get tip commit in repo
+    # It should be different from the initial one (patches + config have applied)
+    assert tip.node != initial.node
+
+    # Check all commits messages
+    assert [c.desc for c in mock_nss.repo.log()] == [
+        b"try: -a -b XXX -c YYY",
+        b"Bug XXX - A second commit message\nDifferential Diff: PHID-DIFF-test123",
+        b"Bug XXX - A first commit message\nDifferential Diff: PHID-DIFF-xxxx",
+        b"Readme",
+    ]
+
+    # Check the push to try has been called
+    # with tip commit
+    ssh_conf = f'ssh -o StrictHostKeyChecking="no" -o User="john@doe.com" -o IdentityFile="{mock_nss.ssh_key_path}"'
+    mock_nss.repo.push.assert_called_with(
+        dest=b"http://nss/try", force=True, rev=tip.node, ssh=ssh_conf.encode("utf-8")
+    )
+
+
+@pytest.mark.asyncio
+async def test_crash_utf8_author(PhabricatorMock, mock_mc):
+    """
+    Run mercurial worker on a single diff
+    but the patch author has utf-8 chars in its name
+    """
+    diff = {
+        "revisionPHID": "PHID-DREV-badutf8",
+        "baseRevision": "missing",
+        "phid": "PHID-DIFF-badutf8",
+        "id": 555,
+    }
+    build = MockBuild(4444, "PHID-REPO-mc", 5555, "PHID-build-badutf8", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    # The patched and config files should not exist at first
+    repo_dir = mock_mc.repo.root().decode("utf-8")
+    config = os.path.join(repo_dir, "try_task_config.json")
+    target = os.path.join(repo_dir, "test.txt")
+    assert not os.path.exists(target)
+    assert not os.path.exists(config)
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": mock_mc}
+    )
+    worker.register(bus)
+    assert len(worker.repositories) == 1
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+
+    # Run the mercurial worker on that patch only
+    task = asyncio.create_task(worker.run())
+    mode, out_build, details = await bus.receive("phabricator")
+    task.cancel()
+
+    # Check we have the patch with utf-8 author properly applied
+    assert [(c.author, c.desc) for c in mock_mc.repo.log()] == [
+        (
+            b"libmozevent <release-mgmt-analysis@mozilla.com>",
+            b"try_task_config for code-review\n"
+            b"Differential Diff: PHID-DIFF-badutf8",
+        ),
+        (
+            b"Andr\xc3\xa9 XXXX <andre.xxxx@allizom.org>",
+            b"This patch has an author with utf8 chars\n"
+            b"Differential Diff: PHID-DIFF-badutf8",
+        ),
+        (b"test", b"Readme"),
+    ]
+
+    # The phab output should be successful
+    assert mode == "success"
+    assert out_build == build
+    assert details[
+        "treeherder_url"
+    ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
+        mock_mc.repo.tip().node.decode("utf-8")
+    )
+    assert details["revision"] == mock_mc.repo.tip().node.decode("utf-8")
+
+
+@responses.activate
+@pytest.mark.asyncio
+async def test_unexpected_push_failure(PhabricatorMock, mock_mc):
+    """
+    When a fail occurs while pushing the file configuring try
+    A new task for the build is added to the bus
+    """
+    diff = {
+        "revisionPHID": "PHID-DREV-badutf8",
+        "baseRevision": "missing",
+        "phid": "PHID-DIFF-badutf8",
+        "id": 555,
+    }
+    build = MockBuild(4444, "PHID-REPO-mc", 5555, "PHID-build-badutf8", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    from libmozevent import mercurial
+
+    mercurial.MAX_PUSH_RETRIES = 1
+    mercurial.TRY_STATUS_URL = "http://test.status/try"
+    mercurial.PUSH_RETRY_EXPONENTIAL_DELAY = 0
+    mercurial.TRY_STATUS_DELAY = 0
+    mercurial.TRY_STATUS_MAX_WAIT = 0
+
+    responses.get(
+        "http://test.status/try", status=200, json={"result": {"status": "open"}}
+    )
+
+    repository_mock = MagicMock(spec=mercurial.Repository)
+    repository_mock.push_to_try.side_effect = [
+        hglib.error.CommandError(
+            args=("push", "try_url"),
+            ret=1,
+            err="abort: push failed on remote",
+            out="",
+        ),
+        mock_mc.repo.tip(),
+    ]
+    repository_mock.try_name = "try"
+    repository_mock.retries = 0
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": repository_mock}
+    )
+    worker.register(bus)
+
+    assert bus.queues["mercurial"].qsize() == 0
+
+    resp = await worker.handle_build(repository_mock, build)
+    assert resp is None
+    assert repository_mock.push_to_try.call_count == 1
+
+    assert bus.queues["mercurial"].qsize() == 1
+    assert bus.queues["phabricator"].qsize() == 0
+
+    # Try a 2nd in a new task
+    build = await bus.receive("mercurial")
+    resp = await worker.handle_build(repository_mock, build)
+    assert resp is not None
+    mode, out_build, details = resp
+
+    assert mode == "success"
+    assert out_build == build
+    tip = mock_mc.repo.tip()
+    assert details[
+        "treeherder_url"
+    ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
+        tip.node.decode("utf-8")
+    )
+    assert details["revision"] == tip.node.decode("utf-8")
+    assert [(call.request.method, call.request.url) for call in responses.calls] == [
+        ("GET", "http://test.status/try")
+    ]
+
+
+@responses.activate
+@pytest.mark.asyncio
+async def test_push_failure_max_retries(PhabricatorMock, mock_mc):
+    """
+    When a fail occurs while pushing the file configuring try
+    A new task for the build is added to the bus
+    """
+    diff = {
+        "revisionPHID": "PHID-DREV-badutf8",
+        "baseRevision": "missing",
+        "phid": "PHID-DIFF-badutf8",
+        "id": 555,
+    }
+    build = MockBuild(4444, "PHID-REPO-mc", 5555, "PHID-build-badutf8", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    from libmozevent import mercurial
+
+    mercurial.MAX_PUSH_RETRIES = 2
+    mercurial.TRY_STATUS_URL = "http://test.status/try"
+    mercurial.PUSH_RETRY_EXPONENTIAL_DELAY = 2
+    mercurial.TRY_STATUS_DELAY = 0
+    mercurial.TRY_STATUS_MAX_WAIT = 0
+
+    sleep_history = []
+
+    class AsyncioMock:
+        async def sleep(self, value):
+            nonlocal sleep_history
+            sleep_history.append(value)
+
+    mercurial.asyncio = AsyncioMock()
+
+    responses.get(
+        "http://test.status/try", status=200, json={"result": {"status": "open"}}
+    )
+
+    repository_mock = MagicMock(spec=mercurial.Repository)
+    repository_mock.push_to_try.side_effect = hglib.error.CommandError(
+        args=("push", "try_url"),
+        ret=1,
+        err="abort: push failed on remote",
+        out="",
+    )
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": repository_mock}
+    )
+    worker.register(bus)
+
+    await bus.send("mercurial", build)
+    assert bus.queues["mercurial"].qsize() == 1
+    task = asyncio.create_task(worker.run())
+
+    # Check the treeherder link was queued
+    mode, out_build, details = await bus.receive("phabricator")
+    task.cancel()
+
+    assert build.retries == 3
+
+    assert mode == "fail:mercurial"
+    assert out_build == build
+    assert details["duration"] > 0
+    assert (
+        details["message"]
+        == "Max number of retries has been reached pushing the build to try repository"
+    )
+
+    assert [(call.request.method, call.request.url) for call in responses.calls] == [
+        ("GET", "http://test.status/try"),
+        ("GET", "http://test.status/try"),
+        ("GET", "http://test.status/try"),
+    ]
+    assert sleep_history == [2, 4, 8]
+
+
+@responses.activate
+@pytest.mark.asyncio
+async def test_push_closed_try(PhabricatorMock, mock_mc):
+    """
+    Detect when try tree is in a closed state and wait before it is opened to retry
+    """
+
+    diff = {
+        "revisionPHID": "PHID-DREV-badutf8",
+        "baseRevision": "missing",
+        "phid": "PHID-DIFF-badutf8",
+        "id": 555,
+    }
+    build = MockBuild(4444, "PHID-REPO-mc", 5555, "PHID-build-badutf8", diff)
+    with PhabricatorMock as phab:
+        phab.load_patches_stack(build)
+
+    bus = MessageBus()
+    bus.add_queue("phabricator")
+
+    from libmozevent import mercurial
+
+    mercurial.MAX_PUSH_RETRIES = 2
+    mercurial.TRY_STATUS_URL = "http://test.status/try"
+    mercurial.PUSH_RETRY_EXPONENTIAL_DELAY = 2
+    mercurial.TRY_STATUS_DELAY = 42
+    mercurial.TRY_STATUS_MAX_WAIT = 1
+
+    sleep_history = []
+
+    class AsyncioMock:
+        async def sleep(self, value):
+            nonlocal sleep_history
+            sleep_history.append(value)
+
+    mercurial.asyncio = AsyncioMock()
+
+    responses.get(
+        "http://test.status/try", status=200, json={"result": {"status": "closed"}}
+    )
+    responses.get("http://test.status/try", status=500)
+    responses.get(
+        "http://test.status/try", status=200, json={"result": {"status": "open"}}
+    )
+
+    repository_mock = MagicMock(spec=mercurial.Repository)
+    repository_mock.push_to_try.side_effect = [
+        hglib.error.CommandError(
+            args=("push", "try_url"),
+            ret=1,
+            err="abort: push failed on remote",
+            out="",
+        ),
+        mock_mc.repo.tip(),
+    ]
+    repository_mock.try_name = "try"
+    repository_mock.retries = 0
+
+    worker = mercurial.MercurialWorker(
+        "mercurial", "phabricator", repositories={"PHID-REPO-mc": repository_mock}
+    )
+    worker.register(bus)
+
+    assert bus.queues["mercurial"].qsize() == 0
+
+    resp = await worker.handle_build(repository_mock, build)
+    assert resp is None
+    assert repository_mock.push_to_try.call_count == 1
+
+    assert bus.queues["mercurial"].qsize() == 1
+    assert bus.queues["phabricator"].qsize() == 0
+
+    build = await bus.receive("mercurial")
+    resp = await worker.handle_build(repository_mock, build)
+    assert resp is not None
+    mode, out_build, details = resp
+
+    assert mode == "success"
+    assert out_build == build
+    tip = mock_mc.repo.tip()
+    assert details[
+        "treeherder_url"
+    ] == "https://treeherder.mozilla.org/#/jobs?repo=try&revision={}".format(
+        tip.node.decode("utf-8")
+    )
+    assert details["revision"] == tip.node.decode("utf-8")
+    assert [(call.request.method, call.request.url) for call in responses.calls] == [
+        ("GET", "http://test.status/try"),
+        ("GET", "http://test.status/try"),
+        ("GET", "http://test.status/try"),
+    ]
+    assert sleep_history == [42, 42, 2]
+
+
+def test_get_base_identifier(mock_mc):
+    stack = [
+        PhabricatorPatch(1, "PHID-abc", "", "abc", None),
+        PhabricatorPatch(2, "PHID-def", "", "def", None),
+        PhabricatorPatch(3, "PHID-ghi", "", "ghi", None),
+    ]
+
+    assert (
+        mock_mc.get_base_identifier(stack) == "abc"
+    ), "The base commit of the stack should be returned."
+
+    mock_mc.use_latest_revision = True
+
+    assert (
+        mock_mc.get_base_identifier(stack) == "tip"
+    ), "`tip` commit should be used when `use_latest_revision` is `True`."

--- a/bot/tests/test_mercurial.py
+++ b/bot/tests/test_mercurial.py
@@ -151,7 +151,7 @@ def test_push_to_try(PhabricatorMock, mock_mc):
 
     # Check all commits authors
     assert [c.author for c in mock_mc.repo.log()] == [
-        b"libmozevent <release-mgmt-analysis@mozilla.com>",
+        b"code review bot <release-mgmt-analysis@mozilla.com>",
         b"John Doe <john@allizom.org>",
         b"randomUsername <random>",
         b"test",
@@ -579,7 +579,7 @@ def test_crash_utf8_author(PhabricatorMock, mock_mc):
     # Check we have the patch with utf-8 author properly applied
     assert [(c.author, c.desc) for c in mock_mc.repo.log()] == [
         (
-            b"libmozevent <release-mgmt-analysis@mozilla.com>",
+            b"code review bot <release-mgmt-analysis@mozilla.com>",
             b"try_task_config for code-review\n"
             b"Differential Diff: PHID-DIFF-badutf8",
         ),

--- a/bot/tests/test_mercurial.py
+++ b/bot/tests/test_mercurial.py
@@ -725,7 +725,7 @@ async def test_unexpected_push_failure(PhabricatorMock, mock_mc):
     bus = MessageBus()
     bus.add_queue("phabricator")
 
-    from libmozevent import mercurial
+    from code_review_bot import mercurial
 
     mercurial.MAX_PUSH_RETRIES = 1
     mercurial.TRY_STATUS_URL = "http://test.status/try"
@@ -804,7 +804,7 @@ async def test_push_failure_max_retries(PhabricatorMock, mock_mc):
     bus = MessageBus()
     bus.add_queue("phabricator")
 
-    from libmozevent import mercurial
+    from code_review_bot import mercurial
 
     mercurial.MAX_PUSH_RETRIES = 2
     mercurial.TRY_STATUS_URL = "http://test.status/try"
@@ -884,7 +884,7 @@ async def test_push_closed_try(PhabricatorMock, mock_mc):
     bus = MessageBus()
     bus.add_queue("phabricator")
 
-    from libmozevent import mercurial
+    from code_review_bot import mercurial
 
     mercurial.MAX_PUSH_RETRIES = 2
     mercurial.TRY_STATUS_URL = "http://test.status/try"


### PR DESCRIPTION
Refs #2827 

This is a rather large chunk of code to import, and even larger when considering the extensive test suite and its fixtures.

I simplified the imported codebase to:
- replace async methods by synchronous (no need anymore to be async)
- remove the bus messaging part (not needed as we directly call the method and expect a single result)
- remove multiple repositories management from `MercurialWorker` as we only need the one from task that is already cloned

I found a small issue in the current `master` implementation: as we call `handle_build` directly, there is no retry on specific errors (due to try being down or rejecting the payload). The test suite identified that missing case easily and I added it back.