### PR TITLE
Remove try syntax

### DIFF
--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -46,7 +46,6 @@ def mock_repositories():
             "decision_env_prefix": "GECKO",
             "checkout": "robust",
             "try_url": "ssh://hg.mozilla.org/try",
-            "try_mode": "json",
             "try_name": "try",
             "name": "mozilla-central",
             "ssh_user": "reviewbot@mozilla.com",
@@ -1069,8 +1068,6 @@ def mock_nss(tmpdir):
         "ssh_key": "privateSSHkey",
         "url": "http://nss",
         "try_url": "http://nss/try",
-        "try_mode": "syntax",
-        "try_syntax": "-a -b XXX -c YYY",
         "batch_size": 100,
     }
     repo = Repository(config, tmpdir.realpath())

--- a/bot/tests/test_mercurial.py
+++ b/bot/tests/test_mercurial.py
@@ -526,7 +526,9 @@ def test_push_to_try_nss(PhabricatorMock, mock_nss):
     assert json.load(open(config)) == {
         "version": 2,
         "parameters": {
-            "code-review": {"phabricator-build-target": "PHID-HMBT-deadbeef"}
+            "optimize_target_tasks": True,
+            "phabricator_diff": "PHID-HMBT-deadbeef",
+            "target_tasks_method": "codereview",
         },
     }
 
@@ -536,7 +538,7 @@ def test_push_to_try_nss(PhabricatorMock, mock_nss):
 
     # Check all commits messages
     assert [c.desc for c in mock_nss.repo.log()] == [
-        b"try: -a -b XXX -c YYY",
+        b"try_task_config for code-review\nDifferential Diff: PHID-DIFF-test123",
         b"Bug XXX - A second commit message\nDifferential Diff: PHID-DIFF-test123",
         b"Bug XXX - A first commit message\nDifferential Diff: PHID-DIFF-xxxx",
         b"Readme",


### PR DESCRIPTION
Followup of #2842

As try syntax [has been deprecated](https://bugzilla.mozilla.org/show_bug.cgi?id=1648719), we can remove the 2 try mode  support (json & syntax) to only use json.