### PR TITLE
Remove the `hg up null` workaround as it is no longer needed

### DIFF
--- a/bot/code_review_bot/mercurial.py
+++ b/bot/code_review_bot/mercurial.py
@@ -325,15 +325,11 @@ class Repository:
             )
             if len(repo_status) != 0:
                 logger.warn(
-                    "Repo is dirty! Let's clean it first.",
+                    "Repo is dirty!",
                     revision=hg_base,
                     repo=self.name,
                     repo_status=repo_status,
                 )
-                # Clean the repo - This is a workaround for Bug 1720302
-                self.repo.update(rev="null", clean=True)
-                # Redo the update to the correct revision
-                self.repo.update(rev=hg_base, clean=True)
 
         except hglib.error.CommandError:
             raise Exception(f"Failed to update to revision {hg_base}")


### PR DESCRIPTION
Essentially reverts https://github.com/mozilla/libmozevent/commit/464816691a9f28a49c84935c7d3d4097536fb060

Fixes #2899