### PR TITLE
Use postgres 17 in CI for backend tests

### DIFF
--- a/backend/ci/setup_postgres.sh
+++ b/backend/ci/setup_postgres.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -ex
-export PG_VERSION=15
+export PG_VERSION=17
 
 # Silent apt
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
This solves the CI latest issue due to `python:3.12` base Debian docker image being updated