### PR TITLE
Don't request the `dind` docker-worker feature

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -125,8 +125,6 @@ tasks:
                 - { $eval: as_slugid("check_lint") }
                 - { $eval: as_slugid("bot_check_tests") }
               payload:
-                features:
-                  dind: true
                 maxRunTime: 3600
                 image: "${taskboot_image}"
                 env:


### PR DESCRIPTION
We don't use docker-in-docker anymore.