### PR TITLE
tgdiff: only add taskgraph-reviewers for gecko patches

### DIFF
--- a/bot/code_review_bot/tasks/tgdiff.py
+++ b/bot/code_review_bot/tasks/tgdiff.py
@@ -80,10 +80,11 @@ class TaskGraphDiffTask(NoticeTask):
         if summary is None:
             logger.warn("Missing summary.json")
         elif "status" in summary and summary["status"] == "WARNING":
-            logger.info(
-                "TaskGraphDiff summary status is in WARNING, the #taskgraph-reviewers group will be added to the revision"
-            )
-            self.extra_reviewers_groups.append("taskgraph-reviewers")
+            if self.task.get("tags", {}).get("trust-domain") == "gecko":
+                logger.info(
+                    "TaskGraphDiff summary status is in WARNING, the #taskgraph-reviewers group will be added to the revision"
+                )
+                self.extra_reviewers_groups.append("taskgraph-reviewers")
 
         # We don't actually want the contents of these artifacts, just their
         # urls (which are now stored in `self.artifact_urls`).

--- a/bot/tests/test_tgdiff_task.py
+++ b/bot/tests/test_tgdiff_task.py
@@ -6,7 +6,10 @@ from code_review_bot.tasks.tgdiff import TaskGraphDiffTask
 @pytest.fixture
 def mock_taskgraph_diff_task():
     tg_task_status = {
-        "task": {"metadata": {"name": "source-test-taskgraph-diff"}},
+        "task": {
+            "metadata": {"name": "source-test-taskgraph-diff"},
+            "tags": {"trust-domain": "gecko"},
+        },
         "status": {
             "taskId": "12345deadbeef",
             "state": "completed",
@@ -14,6 +17,14 @@ def mock_taskgraph_diff_task():
         },
     }
     return TaskGraphDiffTask("12345deadbeef", tg_task_status)
+
+
+@pytest.fixture
+def mock_taskgraph_diff_comm_task(mock_taskgraph_diff_task):
+    mock_taskgraph_diff_task.artifacts.clear()
+    mock_taskgraph_diff_task.extra_reviewers_groups.clear()
+    mock_taskgraph_diff_task.task["tags"]["trust-domain"] = "comm"
+    return mock_taskgraph_diff_task
 
 
 def test_load_artifacts_no_summary(mock_taskcluster_config, mock_taskgraph_diff_task):
@@ -94,3 +105,33 @@ def test_load_artifacts_warning_summary(
         "public/taskgraph/diffs/diff_mc-onpush.txt": "http://tc.test/12345deadbeef/0/artifacts/public/taskgraph/diffs/diff_mc-onpush.txt"
     }
     assert mock_taskgraph_diff_task.extra_reviewers_groups == ["taskgraph-reviewers"]
+
+
+def test_load_artifacts_warning_summary_comm(
+    mock_taskcluster_config, mock_taskgraph_diff_comm_task
+):
+    queue = mock_taskcluster_config.get_service("queue")
+    queue.options = {"rootUrl": "http://taskcluster.test"}
+    queue.configure(
+        {
+            "12345deadbeef": {
+                "artifacts": {
+                    "public/taskgraph/diffs/diff_mc-onpush.txt": "Some diff",
+                    "public/taskgraph/diffs/summary.json": {
+                        "files": {},
+                        "status": "WARNING",
+                        "threshold": 20,
+                    },
+                    "public/taskgraph/not_a_diff.txt": "Not a diff",
+                }
+            }
+        }
+    )
+
+    mock_taskgraph_diff_comm_task.load_artifacts(queue)
+
+    # The summary.json is WARNING, but the task is not from gecko so no extra reviewer group is added
+    assert mock_taskgraph_diff_comm_task.artifact_urls == {
+        "public/taskgraph/diffs/diff_mc-onpush.txt": "http://tc.test/12345deadbeef/0/artifacts/public/taskgraph/diffs/diff_mc-onpush.txt"
+    }
+    assert mock_taskgraph_diff_comm_task.extra_reviewers_groups == []


### PR DESCRIPTION
The taskgraph-reviewers group isn't meant to review thunderbird changes.