### PR TITLE
Use revision base changeset as repo starting point for patches

### DIFF
--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -287,6 +287,8 @@ class Workflow:
                 "ssh_key": settings.ssh_key,
                 # Force usage of robustcheckout
                 "checkout": "robust",
+                # Custom default revision to rebase patches onto
+                "default_revision": revision.base_changeset,
             },
             cache_root=settings.mercurial_cache,
         )


### PR DESCRIPTION
Closes #2811 

While looking into #2972 I found that part of the issue could come from #2811

It's now easy to do since we onboarded the libmozevent mercurial code in #2842