### PR TITLE
Disable the Phabricator reporter when analysing a GitHub revision

### DIFF
--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -254,7 +254,7 @@ def main():
             duration=0,
         )
 
-        if phabricator_reporting_enabled:
+        if phabricator_reporting_enabled and isinstance(revision, PhabricatorRevision):
             w.phabricator.update_build_target(
                 revision.build_target_phid, BuildState.Fail, unit=[failure]
             )

--- a/bot/code_review_bot/cli.py
+++ b/bot/code_review_bot/cli.py
@@ -67,7 +67,7 @@ def parse_cli():
     parser.add_argument(
         "--github-repository",
         help="Optional path to a up-to-date github repository matching the analyzed revision.\n"
-        "This argument is required for Github reviusions in order to compute issues' hashes based on file content.",
+        "This argument is required for Github revisions in order to compute issues' hashes based on file content.",
         type=Path,
         default=None,
     )

--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -12,6 +12,7 @@ from libmozdata.phabricator import BuildState, PhabricatorAPI
 from code_review_bot import Issue, Level, stats
 from code_review_bot.backend import BackendAPI
 from code_review_bot.report.base import Reporter
+from code_review_bot.revisions import PhabricatorRevision
 from code_review_bot.tasks.clang_tidy_external import ExternalTidyIssue
 from code_review_bot.tasks.coverage import CoverageIssue
 from code_review_bot.tools import treeherder
@@ -163,6 +164,11 @@ class PhabricatorReporter(Reporter):
         * publishable issues use lint results
         * build errors are displayed as unit test results
         """
+        if not isinstance(revision, PhabricatorRevision):
+            logger.debug(
+                f"Skipping Phabricator publication ({revision.__class__.__name__})"
+            )
+            return
 
         # Add extra reviewers groups to the revision
         if reviewers:

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -98,7 +98,7 @@ class Workflow:
 
         # Set the Phabricator build as running
         self.update_status(revision, state=BuildState.Work)
-        if settings.taskcluster_url:
+        if settings.taskcluster_url and isinstance(revision, PhabricatorRevision):
             self.publish_link(
                 revision,
                 slug="publication",
@@ -278,7 +278,7 @@ class Workflow:
 
         # Set the Phabricator build as running
         self.update_status(revision, state=BuildState.Work)
-        if settings.taskcluster_url:
+        if settings.taskcluster_url and isinstance(revision, PhabricatorRevision):
             self.publish_link(
                 revision,
                 slug="analysis",
@@ -347,7 +347,7 @@ class Workflow:
         self.index(revision, state="pushed_to_try")
 
         # Update final state using worker output
-        if self.update_build:
+        if self.update_build and isinstance(revision, PhabricatorRevision):
             publish_analysis_phabricator(output, self.phabricator)
         else:
             logger.info("Skipping Phabricator publication")
@@ -726,7 +726,7 @@ class Workflow:
             )
             return
 
-        if not self.update_build:
+        if not self.update_build or not isinstance(revision, PhabricatorRevision):
             logger.info(
                 "Update build disabled, skipping HarborMaster update", state=state.value
             )


### PR DESCRIPTION
Follow up #3255 

This allows both Phabricator and GitHub publishers to be added concurrently in the configuration:
```
---
bot:
  REPORTERS:
    - reporter: phabricator
    - reporter: github
      client_id: xxxxxxxxxxxxxxxxxxxx
      private_key_pem: |-
        -----BEGIN RSA PRIVATE KEY-----
        XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
        XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
        -----END RSA PRIVATE KEY-----
      installation_id: 123456789
```