### PR TITLE
Implement Taskcluster index namespaces for github revisions

### DIFF
--- a/bot/code_review_bot/revisions/github.py
+++ b/bot/code_review_bot/revisions/github.py
@@ -59,6 +59,16 @@ class GithubRevision(Revision):
         """
         return build_repo_slug(self.base_repository)
 
+    @property
+    def namespaces(self):
+        _head_repository_slug = build_repo_slug(self.head_repository)
+        return [
+            f"github.base.{self.repository_slug}.pr.{self.pull_number}",
+            f"github.base.{self.repository_slug}.rev.{self.base_changeset}",
+            f"github.base.{_head_repository_slug}.pr.{self.pull_number}",
+            f"github.base.{_head_repository_slug}.rev.{self.head_changeset}",
+        ]
+
     def load_patch(self):
         """
         Load the patch content for the current pull request HEAD

--- a/bot/code_review_bot/revisions/github.py
+++ b/bot/code_review_bot/revisions/github.py
@@ -65,8 +65,8 @@ class GithubRevision(Revision):
         return [
             f"github.base.{self.repository_slug}.pr.{self.pull_number}",
             f"github.base.{self.repository_slug}.rev.{self.base_changeset}",
-            f"github.base.{_head_repository_slug}.pr.{self.pull_number}",
-            f"github.base.{_head_repository_slug}.rev.{self.head_changeset}",
+            f"github.head.{_head_repository_slug}.pr.{self.pull_number}",
+            f"github.head.{_head_repository_slug}.rev.{self.head_changeset}",
         ]
 
     def load_patch(self):

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -302,7 +302,7 @@ def mock_github(mock_config):
 
     responses.add(
         responses.GET,
-        "https://github.tests.com/owner/repo-name/pull/1.diff",
+        "https://github.com/owner/repo-name/pull/1.diff",
         json=diff,
     )
     responses.add(
@@ -311,7 +311,7 @@ def mock_github(mock_config):
         json=[
             {
                 "id": 123456789,
-                "access_tokens_url": "https://github.tests.com/app/installations/123456789/access_tokens",
+                "access_tokens_url": "https://github.com/app/installations/123456789/access_tokens",
             }
         ],
     )
@@ -359,9 +359,9 @@ def mock_github_decision_task():
         "payload": {
             "env": {
                 "GECKO_REPOSITORY_TYPE": "git",
-                "GECKO_HEAD_REPOSITORY": "https://github.tests.com/owner/repo-name",
+                "GECKO_HEAD_REPOSITORY": "https://github.com/owner/repo-name",
                 "GECKO_HEAD_REV": "a" * 40,
-                "GECKO_BASE_REPOSITORY": "https://github.tests.com/owner/repo-name",
+                "GECKO_BASE_REPOSITORY": "https://github.com/owner/repo-name",
                 "GECKO_BASE_REV": "b" * 40,
                 "GECKO_PULL_REQUEST_NUMBER": 1,
             }
@@ -428,6 +428,20 @@ def mock_revision_autoland(mock_phabricator, mock_autoland_task):
 
     with mock_phabricator as api:
         return PhabricatorRevision.from_decision_task(mock_autoland_task, api)
+
+
+@pytest.fixture
+def mock_github_revision(
+    mock_github, mock_try_task, mock_github_decision_task, mock_config
+):
+    """
+    Mock a github revision
+    """
+    from code_review_bot.revisions import GithubRevision, Revision
+
+    revision = Revision.from_try_task(mock_try_task, mock_github_decision_task, None)
+    assert isinstance(revision, GithubRevision)
+    return revision
 
 
 class Response:

--- a/bot/tests/test_index.py
+++ b/bot/tests/test_index.py
@@ -268,12 +268,12 @@ def test_github_index(
     assert [c[0][0] for c in calls] == [
         "project.relman.test.code-review.github.base.owner_repo-name.pr.1",
         "project.relman.test.code-review.github.base.owner_repo-name.rev.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-        "project.relman.test.code-review.github.base.owner_repo-name.pr.1",
-        "project.relman.test.code-review.github.base.owner_repo-name.rev.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "project.relman.test.code-review.github.head.owner_repo-name.pr.1",
+        "project.relman.test.code-review.github.head.owner_repo-name.rev.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         "project.relman.test.code-review.github.base.owner_repo-name.pr.1.12345deadbeef",
         "project.relman.test.code-review.github.base.owner_repo-name.rev.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.12345deadbeef",
-        "project.relman.test.code-review.github.base.owner_repo-name.pr.1.12345deadbeef",
-        "project.relman.test.code-review.github.base.owner_repo-name.rev.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.12345deadbeef",
+        "project.relman.test.code-review.github.head.owner_repo-name.pr.1.12345deadbeef",
+        "project.relman.test.code-review.github.head.owner_repo-name.rev.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.12345deadbeef",
     ]
 
     # Check all calls have the same shared payload

--- a/bot/tests/test_index.py
+++ b/bot/tests/test_index.py
@@ -248,3 +248,48 @@ def test_index_from_try(
         "url": "https://phabricator.test/D51",
     }
     assert all([c[0][1]["data"] == payload for c in calls])
+
+
+def test_github_index(
+    mock_github_revision,
+    mock_decision_task,
+    mock_workflow,
+    mock_config,
+    mock_taskcluster_date,
+):
+    mock_workflow.index_service = mock.Mock()
+    mock_config.taskcluster = TaskCluster("/tmp/dummy", "12345deadbeef", 0, False)
+
+    mock_workflow.index(mock_github_revision, state="unit-test")
+
+    assert mock_workflow.index_service.insertTask.call_count == 8
+    calls = mock_workflow.index_service.insertTask.call_args_list
+
+    assert [c[0][0] for c in calls] == [
+        "project.relman.test.code-review.github.base.owner_repo-name.pr.1",
+        "project.relman.test.code-review.github.base.owner_repo-name.rev.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "project.relman.test.code-review.github.base.owner_repo-name.pr.1",
+        "project.relman.test.code-review.github.base.owner_repo-name.rev.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "project.relman.test.code-review.github.base.owner_repo-name.pr.1.12345deadbeef",
+        "project.relman.test.code-review.github.base.owner_repo-name.rev.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.12345deadbeef",
+        "project.relman.test.code-review.github.base.owner_repo-name.pr.1.12345deadbeef",
+        "project.relman.test.code-review.github.base.owner_repo-name.rev.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.12345deadbeef",
+    ]
+
+    print(calls[0][0][1]["data"])
+
+    # Check all calls have the same shared payload
+    payload = {
+        "base_repository": "https://github.com/owner/repo-name",
+        "base_changeset": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "head_repository": "https://github.com/owner/repo-name",
+        "head_changeset": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "pull_number": 1,
+        "state": "unit-test",
+        "indexed": "2025-10-30T00:00:00.00Z",
+        "source": "try",
+        "try_task_id": "remoteTryTask",
+        "try_group_id": "remoteTryGroup",
+        "monitoring_restart": False,
+    }
+    assert all([c[0][1]["data"] == payload for c in calls])

--- a/bot/tests/test_index.py
+++ b/bot/tests/test_index.py
@@ -276,8 +276,6 @@ def test_github_index(
         "project.relman.test.code-review.github.base.owner_repo-name.rev.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.12345deadbeef",
     ]
 
-    print(calls[0][0][1]["data"])
-
     # Check all calls have the same shared payload
     payload = {
         "base_repository": "https://github.com/owner/repo-name",

--- a/bot/tests/test_reporter_github.py
+++ b/bot/tests/test_reporter_github.py
@@ -76,7 +76,7 @@ def test_github_review(
 
     reporter.publish([issue_clang_tidy, issue_coverage], revision, [], [], [])
     assert [(call.request.method, call.request.url) for call in responses.calls] == [
-        ("GET", "https://github.tests.com/owner/repo-name/pull/1.diff"),
+        ("GET", "https://github.com/owner/repo-name/pull/1.diff"),
         ("GET", "https://api.github.com:443/app/installations"),
         (
             "POST",
@@ -141,7 +141,7 @@ def test_github_review_approve(
 
     reporter.publish([], revision, [], [], [])
     assert [(call.request.method, call.request.url) for call in responses.calls] == [
-        ("GET", "https://github.tests.com/owner/repo-name/pull/1.diff"),
+        ("GET", "https://github.com/owner/repo-name/pull/1.diff"),
         ("GET", "https://api.github.com:443/app/installations"),
         (
             "POST",


### PR DESCRIPTION
This was missed during earlier development as Taskcluster index is not enabled during local runs (as we cannot write on Taskcluster APIs without some authentication).