### PR TITLE
Skip incompatible reporters for github & phabricator revisions

### DIFF
--- a/bot/code_review_bot/git.py
+++ b/bot/code_review_bot/git.py
@@ -32,8 +32,6 @@ def git_clone(base_repository, head_repository, revision, destination):
     base_slug = build_repo_slug(base_repository)
     head_slug = build_repo_slug(head_repository)
 
-    logger.info(base_slug, head_slug)
-
     # Clone or fetch upstream
     path = destination / base_slug
     if path.exists() and (path / ".git").is_dir():

--- a/bot/code_review_bot/report/github.py
+++ b/bot/code_review_bot/report/github.py
@@ -5,6 +5,7 @@
 import structlog
 
 from code_review_bot.report.base import Reporter
+from code_review_bot.revisions import GithubRevision
 from code_review_bot.sources.github import GithubClient, ReviewEvent
 
 logger = structlog.get_logger(__name__)
@@ -34,6 +35,12 @@ class GithubReporter(Reporter):
         """
         Publish issues on a Github pull request.
         """
+        if not isinstance(revision, GithubRevision):
+            logger.info(
+                "Skipping github reporting, only available for Github revisions"
+            )
+            return
+
         if reviewers:
             raise NotImplementedError
         # Avoid publishing a patch from a de-activated analyzer

--- a/bot/code_review_bot/report/mail_builderrors.py
+++ b/bot/code_review_bot/report/mail_builderrors.py
@@ -6,6 +6,7 @@ import structlog
 
 from code_review_bot import taskcluster
 from code_review_bot.report.base import Reporter
+from code_review_bot.revisions import PhabricatorRevision
 
 logger = structlog.get_logger(__name__)
 
@@ -34,6 +35,12 @@ class BuildErrorsReporter(Reporter):
         """
         Send an email to the author of the revision
         """
+        if not isinstance(revision, PhabricatorRevision):
+            logger.info(
+                "Skipping build error reporting, only available for Phabricator revisions"
+            )
+            return
+
         assert (
             revision.phabricator_id and revision.phabricator_phid
         ), "PhabricatorRevision must have a Phabricator ID and PHID"


### PR DESCRIPTION
Only Github revision should trigger the github reporter.

The build error mail reporter is only compatible with Phabricator revisions currently, as it would require to load user information from github, and we do not have the required github app scopes for that (could be done as a followup, but this unblocks testing execution).