### PR TITLE
Support issues detected outside the patch on GitHub revisions

### DIFF
--- a/bot/code_review_bot/report/github.py
+++ b/bot/code_review_bot/report/github.py
@@ -53,37 +53,39 @@ class GithubReporter(Reporter):
             if issue.is_publishable()
             and issue.analyzer.name not in self.analyzers_skipped
         ]
-        # Issues that are not in patch cannot be published directly through a Github review
-        inside_patch_issues = [issue for issue in publishable_issues if issue.in_patch]
-        outside_patch_issues = [
-            issue for issue in publishable_issues if not issue.in_patch
-        ]
 
         # Remove any earlier review to get a clean state
         nb_dismissed = self.github_client.cleanup_pr(revision)
 
         if publishable_issues:
+            messages = [
+                f"{len(publishable_issues)} issue{'s' if len(publishable_issues) > 1 else ''} "
+                f"{'have' if len(publishable_issues) > 1 else 'has'} "
+                "been found in this revision."
+            ]
+
+            # Issues that are not in patch cannot be published directly through a Github review
+            inside_patch_issues = [
+                issue for issue in publishable_issues if issue.in_patch
+            ]
+            outside_patch_issues = [
+                issue for issue in publishable_issues if not issue.in_patch
+            ]
             if outside_patch_issues:
-                # Directly publish a comment to the PR for issues outside of the patch
-                message = [
-                    f"Code review bot detected {len(outside_patch_issues)} issue{'s' if len(issues) > 1 else ''} "
-                    "outside of the patch:"
-                ]
-                for issue in outside_patch_issues:
-                    message.append(f"* `{issue.path}:{issue.line}` {issue.as_text()}")
-                self.github_client.publish_comment(
-                    revision=revision, message="\n".join(message)
+                # Mention issues outside of the patch in the review main comment, after a new line
+                messages.append("")
+                messages.append(
+                    f"{len(outside_patch_issues)} issue{'s' if len(outside_patch_issues) > 1 else ''} "
+                    f"{'are' if len(outside_patch_issues) > 1 else 'is'} located outside of the patch:"
                 )
+                for issue in outside_patch_issues:
+                    messages.append(f"* `{issue.path}:{issue.line}` {issue.as_text()}")
 
             # Publish a review summarizing detected, unresolved and closed issues
             self.github_client.publish_review(
                 issues=inside_patch_issues,
                 revision=revision,
-                message=(
-                    f"{len(publishable_issues)} issue{'s' if len(publishable_issues) > 1 else ''} "
-                    f"{'have' if len(publishable_issues) > 1 else 'has'} "
-                    "been found in this revision"
-                ),
+                message="\n".join(messages),
                 event=ReviewEvent.RequestChanges,
             )
         else:

--- a/bot/code_review_bot/report/github.py
+++ b/bot/code_review_bot/report/github.py
@@ -53,16 +53,37 @@ class GithubReporter(Reporter):
             if issue.is_publishable()
             and issue.analyzer.name not in self.analyzers_skipped
         ]
+        # Issues that are not in patch cannot be published directly through a Github review
+        inside_patch_issues = [issue for issue in publishable_issues if issue.in_patch]
+        outside_patch_issues = [
+            issue for issue in publishable_issues if not issue.in_patch
+        ]
 
         # Remove any earlier review to get a clean state
         nb_dismissed = self.github_client.cleanup_pr(revision)
 
         if publishable_issues:
+            if outside_patch_issues:
+                # Directly publish a comment to the PR for issues outside of the patch
+                message = [
+                    f"Code review bot detected {len(outside_patch_issues)} issue{'s' if len(issues) > 1 else ''} "
+                    "outside of the patch:"
+                ]
+                for issue in outside_patch_issues:
+                    message.append(f"* `{issue.path}:{issue.line}` {issue.as_text()}")
+                self.github_client.publish_comment(
+                    revision=revision, message="\n".join(message)
+                )
+
             # Publish a review summarizing detected, unresolved and closed issues
             self.github_client.publish_review(
-                issues=publishable_issues,
+                issues=inside_patch_issues,
                 revision=revision,
-                message=f"{len(publishable_issues)} issues have been found in this revision",
+                message=(
+                    f"{len(publishable_issues)} issue{'s' if len(publishable_issues) > 1 else ''} "
+                    f"{'have' if len(publishable_issues) > 1 else 'has'} "
+                    "been found in this revision"
+                ),
                 event=ReviewEvent.RequestChanges,
             )
         else:

--- a/bot/tests/test_reporter_github.py
+++ b/bot/tests/test_reporter_github.py
@@ -106,7 +106,6 @@ def test_github_review(
             "GET",
             "https://api.github.com:443/repos/owner/repo-name/pulls/1/reviews",
         ),
-        ("POST", "https://api.github.com:443/repos/owner/repo-name/pulls/1/comments"),
         (
             "GET",
             "https://api.github.com:443/repos/owner/repo-name",
@@ -121,22 +120,15 @@ def test_github_review(
         ),
         ("POST", "https://api.github.com:443/repos/owner/repo-name/pulls/1/reviews"),
     ]
-    comment_body = next(
-        call.request.body
-        for call in responses.calls
-        if (call.request.method, call.request.url)
-        == ("POST", "https://api.github.com:443/repos/owner/repo-name/pulls/1/comments")
-    )
-    assert json.loads(comment_body) == {
-        "body": dedent("""
-            Code review bot detected 1 issues outside of the patch:
-            * `path/to/test.cpp:1` This file is uncovered
-        """).strip()
-    }
 
     review_creation = responses.calls[-1]
     assert json.loads(review_creation.request.body) == {
-        "body": "2 issues have been found in this revision",
+        "body": dedent("""
+            2 issues have been found in this revision.
+
+            1 issue is located outside of the patch:
+            * `path/to/test.cpp:1` This file is uncovered
+        """).strip(),
         "comments": [
             {
                 "body": "dummy message",

--- a/bot/tests/test_reporter_github.py
+++ b/bot/tests/test_reporter_github.py
@@ -5,6 +5,7 @@
 
 import json
 from pathlib import Path
+from textwrap import dedent
 
 import responses
 from conftest import FIXTURES_DIR
@@ -57,6 +58,7 @@ def test_github_review(
         "modernize-use-nullptr",
         "dummy message",
     )
+    assert issue_clang_tidy.in_patch is True
     assert issue_clang_tidy.is_publishable()
 
     issue_coverage = CoverageIssue(
@@ -66,7 +68,15 @@ def test_github_review(
         "This file is uncovered",
         revision,
     )
+    assert issue_coverage.in_patch is False
     assert issue_coverage.is_publishable()
+
+    # Mock to publish a comment, regarding issues outside of the patch
+    responses.add(
+        responses.POST,
+        "https://api.github.com:443/repos/owner/repo-name/pulls/1/comments",
+        json={},
+    )
 
     # Mock to publish a new review
     responses.add(
@@ -96,6 +106,7 @@ def test_github_review(
             "GET",
             "https://api.github.com:443/repos/owner/repo-name/pulls/1/reviews",
         ),
+        ("POST", "https://api.github.com:443/repos/owner/repo-name/pulls/1/comments"),
         (
             "GET",
             "https://api.github.com:443/repos/owner/repo-name",
@@ -110,6 +121,19 @@ def test_github_review(
         ),
         ("POST", "https://api.github.com:443/repos/owner/repo-name/pulls/1/reviews"),
     ]
+    comment_body = next(
+        call.request.body
+        for call in responses.calls
+        if (call.request.method, call.request.url)
+        == ("POST", "https://api.github.com:443/repos/owner/repo-name/pulls/1/comments")
+    )
+    assert json.loads(comment_body) == {
+        "body": dedent("""
+            Code review bot detected 1 issues outside of the patch:
+            * `path/to/test.cpp:1` This file is uncovered
+        """).strip()
+    }
+
     review_creation = responses.calls[-1]
     assert json.loads(review_creation.request.body) == {
         "body": "2 issues have been found in this revision",
@@ -118,11 +142,6 @@ def test_github_review(
                 "body": "dummy message",
                 "path": "another_test.cpp",
                 "line": 42,
-            },
-            {
-                "body": "This file is uncovered",
-                "path": "path/to/test.cpp",
-                "line": 1,
             },
         ],
         "commit_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",


### PR DESCRIPTION
The issues that are outside the patch but should be published (e.g. level == "error") are reported in a comment, directly on the Pull Request.

This patch fixes the error from analysis of [mozilla-firefox/firefox PR #268](https://firefox-ci-tc.services.mozilla.com/tasks/JC-4gfYuTh20FUj0fS3qYw/runs/0/logs/public/logs/live.log). Reproduced at https://github.com/vrigal/ff-test/pull/3.