### PR TITLE
Avoid harbormaster crash when publishing a link

### DIFF
--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from itertools import groupby
 
 import structlog
-from libmozdata.phabricator import BuildState, PhabricatorAPI
+from libmozdata.phabricator import BuildState, ConduitError, PhabricatorAPI
 from taskcluster.utils import stringDate
 
 from code_review_bot import Level, stats
@@ -760,6 +760,16 @@ class Workflow:
             )
             return
 
-        self.phabricator.create_harbormaster_uri(
-            revision.build_target_phid, slug, name, url
-        )
+        try:
+            self.phabricator.create_harbormaster_uri(
+                revision.build_target_phid, slug, name, url
+            )
+        except ConduitError as e:
+            logger.warn(
+                "Failed to publish a URI on harbormaster",
+                build=revision.build_target_phid,
+                slug=slug,
+                name=name,
+                url=url,
+                error=str(e),
+            )

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -269,6 +269,13 @@ def mock_phabricator(mock_config):
         content_type="application/json",
     )
 
+    responses.add(
+        responses.POST,
+        "http://phabricator.test/api/harbormaster.createartifact",
+        body=_response("harbormaster_createartifact"),
+        content_type="application/json",
+    )
+
     config_file = tempfile.NamedTemporaryFile()
     with open(config_file.name, "w") as f:
         custom_conf = ConfigParser()

--- a/bot/tests/mocks/phabricator_harbormaster_createartifact.json
+++ b/bot/tests/mocks/phabricator_harbormaster_createartifact.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+  },
+  "error_code": null,
+  "error_info": null
+}

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -5,11 +5,13 @@
 import os
 from datetime import datetime
 from unittest import mock
+from urllib.parse import unquote_plus
 
 import pytest
 import responses
 
 from code_review_bot.config import Settings
+from code_review_bot.revisions import PhabricatorRevision
 from code_review_bot.tasks.clang_format import ClangFormatIssue, ClangFormatTask
 from code_review_bot.tasks.clang_tidy import ClangTidyTask
 from code_review_bot.tasks.clang_tidy_external import ExternalTidyTask
@@ -168,3 +170,31 @@ def test_before_after(mock_taskcluster_config, mock_workflow, mock_task, mock_re
     ]
     assert issues[0].new_issue is True
     assert issues[1].new_issue is False
+
+
+def test_publish_link(mock_phabricator, mock_workflow):
+    # Allow build updates
+    mock_workflow.update_build = True
+
+    with mock_phabricator as api:
+        mock_workflow.phabricator = api
+
+        revision = PhabricatorRevision.from_phabricator_trigger(
+            build_target_phid="PHID-HMBT-test",
+            phabricator=api,
+        )
+        mock_workflow.publish_link(
+            revision,
+            "some-unique-code",
+            "A nice display name",
+            "http://taskcluster/x.y.z",
+        )
+
+    # Check request & response for the link publication
+    call = responses.calls[-1]
+    assert call.request.method == "POST"
+    assert call.request.url == "http://phabricator.test/api/harbormaster.createartifact"
+    assert (
+        unquote_plus(call.request.body)
+        == 'params={"buildTargetPHID": "PHID-HMBT-test", "artifactType": "uri", "artifactKey": "some-unique-code", "artifactData": {"uri": "http://taskcluster/x.y.z", "name": "A nice display name", "ui.external": true}, "__conduit__": {"token": "deadbeef"}}&output=json'
+    )


### PR DESCRIPTION
By looking at recent [erroneous tasks from Taskcluster prod environement](https://code-review.moz.tools/#/tasks) (filtering by state `error`), I noticed that most of the issues come from an exception raised early in some analysis tasks that fail to publish a link on harbormaster.

The Phabricator API raises a 400 about duplicates (which is OK), but the bot immediately crashes.

I simply added a try/except clause around the publication, and a unit test to cover the happy path (no existing tests  on that method).