### PR TITLE
Check backend database is UP through a Python script

### DIFF
--- a/backend/docker/entrypoint.sh
+++ b/backend/docker/entrypoint.sh
@@ -5,12 +5,7 @@
 set -euo pipefail
 
 # Ensure the database accepts connections
-echo "Checking database status at $DATABASE_URL"
-while ! nc -z db 5432; do
-    echo "-----> Waiting for PostgreSQL server to be ready"
-    sleep 1;
-done
-echo "-----> PostgreSQL service is available"
+python /src/backend/docker/wait_for_db.py
 
 # Run the migrations
 ./manage.py migrate --noinput

--- a/backend/docker/wait_for_db.py
+++ b/backend/docker/wait_for_db.py
@@ -1,0 +1,53 @@
+import os
+import socket
+import sys
+import time
+from urllib.parse import urlparse
+
+
+def connect(host, port):
+    client = socket.socket(family=socket.AF_INET, type=socket.SOCK_STREAM)
+    try:
+        client.connect((host, port))
+        client.close()
+    except Exception as e:
+        print(f"Failed to connect: {e!r}")
+        return False
+
+    return True
+
+
+def main():
+    # Get Database URL
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        raise Exception("Missing DATABASE_URL environment variable")
+
+    # Get host from that database url
+    parts = urlparse(db_url)
+    host = parts.hostname
+    port = parts.port or 5432
+    print(f"Checking Postgres host is up at {host} (port {port})")
+
+    # Try to connect to the DB opening a TCP socket
+    max_tries = 20
+    for i in range(max_tries):
+        print(f"Try {i+1}/{max_tries}")
+
+        if connect(host, port):
+            print("Connection successful")
+            return
+
+        # Wait a bit until next try
+        time.sleep(2)
+
+    # All tries failed, so we fail the script too
+    raise Exception("All tries failed, DB is not available")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"ERROR: {e!r}")
+        sys.exit(1)

--- a/backend/docker/wait_for_db.py
+++ b/backend/docker/wait_for_db.py
@@ -11,7 +11,7 @@ def connect(host, port):
         client.connect((host, port))
         client.close()
     except Exception as e:
-        print(f"Failed to connect: {e!r}")
+        print(f"Failed to connect: {e!r}", file=sys.stderr)
         return False
 
     return True
@@ -27,15 +27,15 @@ def main():
     parts = urlparse(db_url)
     host = parts.hostname
     port = parts.port or 5432
-    print(f"Checking Postgres host is up at {host} (port {port})")
+    print(f"Checking Postgres host is up at {host} (port {port})", file=sys.stderr)
 
     # Try to connect to the DB opening a TCP socket
     max_tries = 20
     for i in range(max_tries):
-        print(f"Try {i+1}/{max_tries}")
+        print(f"Try {i+1}/{max_tries}", file=sys.stderr)
 
         if connect(host, port):
-            print("Connection successful")
+            print("Connection successful", file=sys.stderr)
             return
 
         # Wait a bit until next try
@@ -49,5 +49,5 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        print(f"ERROR: {e!r}")
+        print(f"ERROR: {e!r}", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
The entrypoint was assuming the database is always hosted on `db` host, which works locally with docker stack, but not on Heroku.

I made a Python script instead that:
1. parses the `DATABASE_URL` environment variable provided by Heroku & the local docker-compose
2. connects through TCP on the host & port
3. does not retry indefinitely, so the Heroku monitoring (or docker-compose) can report on failed containers after 20 attempts