### PR TITLE
stop adding #taskgraph-reviewers as a reviewer when tasks change

### DIFF
--- a/bot/code_review_bot/tasks/tgdiff.py
+++ b/bot/code_review_bot/tasks/tgdiff.py
@@ -79,12 +79,6 @@ class TaskGraphDiffTask(NoticeTask):
         logger.info("Parsing the summary.json artifact if it exists", task_id=self.id)
         if summary is None:
             logger.warn("Missing summary.json")
-        elif "status" in summary and summary["status"] == "WARNING":
-            if self.task.get("tags", {}).get("trust-domain") == "gecko":
-                logger.info(
-                    "TaskGraphDiff summary status is in WARNING, the #taskgraph-reviewers group will be added to the revision"
-                )
-                self.extra_reviewers_groups.append("taskgraph-reviewers")
 
         # We don't actually want the contents of these artifacts, just their
         # urls (which are now stored in `self.artifact_urls`).

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -990,11 +990,7 @@ class MockPhabricator:
         params = self.parse_request(request, ("constraints",))
 
         result = None
-        if params["constraints"]["slugs"] == ["taskgraph-reviewers"]:
-            result = [
-                {"phid": "PHID-123456789-TGReviewers", "slug": "taskgraph-reviewers"}
-            ]
-        elif params["constraints"]["slugs"] == ["accessibility-frontend-reviewers"]:
+        if params["constraints"]["slugs"] == ["accessibility-frontend-reviewers"]:
             result = [
                 {
                     "phid": "PHID-123456789-A11yReviewers",

--- a/bot/tests/test_reporter_phabricator.py
+++ b/bot/tests/test_reporter_phabricator.py
@@ -1058,13 +1058,8 @@ def test_phabricator_tgdiff(mock_phabricator, phab, mock_try_task, mock_decision
         revision,
         [],
         [doc_notice],
-        ["taskgraph-reviewers"],
+        [],
     )
-
-    # Check the reviewer group has been added to the revision
-    assert phab.transactions[51] == [
-        [{"type": "reviewers.add", "value": ["PHID-123456789-TGReviewers"]}]
-    ]
 
     # Check the comment has been posted
     assert phab.comments[51] == [VALID_NOTICE_MESSAGE.format(notice=doc_notice.strip())]

--- a/bot/tests/test_tgdiff_task.py
+++ b/bot/tests/test_tgdiff_task.py
@@ -100,11 +100,10 @@ def test_load_artifacts_warning_summary(
 
     mock_taskgraph_diff_task.load_artifacts(queue)
 
-    # The summary.json is WARNING, so an extra reviewer group is added and we don't load it in the artifact_urls list
     assert mock_taskgraph_diff_task.artifact_urls == {
         "public/taskgraph/diffs/diff_mc-onpush.txt": "http://tc.test/12345deadbeef/0/artifacts/public/taskgraph/diffs/diff_mc-onpush.txt"
     }
-    assert mock_taskgraph_diff_task.extra_reviewers_groups == ["taskgraph-reviewers"]
+    assert mock_taskgraph_diff_task.extra_reviewers_groups == []
 
 
 def test_load_artifacts_warning_summary_comm(


### PR DESCRIPTION
We have a herald rule that covers our needs here, and this is causing a significant amount of spam (https://github.com/mozilla/code-review/issues/1717, https://bugzilla.mozilla.org/show_bug.cgi?id=2055053).