### PR TITLE
Fix binary issue file handling

### DIFF
--- a/bot/code_review_bot/revisions/base.py
+++ b/bot/code_review_bot/revisions/base.py
@@ -174,8 +174,8 @@ class Revision(ABC):
             try:
                 with (local_cache_repository / file_path).open() as f:
                     file_content = f.read()
-            except (FileNotFoundError, IsADirectoryError):
-                logger.warning("Failed to find issue's related file", path=file_path)
+            except (FileNotFoundError, IsADirectoryError, UnicodeDecodeError):
+                logger.warning("Failed to read issue's related file", path=file_path)
                 file_content = None
         else:
             try:

--- a/bot/code_review_bot/revisions/base.py
+++ b/bot/code_review_bot/revisions/base.py
@@ -174,8 +174,14 @@ class Revision(ABC):
             try:
                 with (local_cache_repository / file_path).open() as f:
                     file_content = f.read()
-            except (FileNotFoundError, IsADirectoryError, UnicodeDecodeError):
-                logger.warning("Failed to read issue's related file", path=file_path)
+            except (FileNotFoundError, IsADirectoryError):
+                logger.warning("Failed to find issue's related file", path=file_path)
+                file_content = None
+            except UnicodeDecodeError:
+                logger.warning(
+                    "Failed to decode issue's related file, it is not text",
+                    path=file_path,
+                )
                 file_content = None
         else:
             try:

--- a/bot/tests/test_revisions.py
+++ b/bot/tests/test_revisions.py
@@ -93,6 +93,13 @@ def test_autoland(mock_config, mock_revision_autoland):
     )
 
 
+def test_binary_file_content_is_ignored(mock_revision, tmp_path):
+    binary_file = tmp_path / "artifact.webp"
+    binary_file.write_bytes(b"RIFF\xac=\x00\x00WEBP")
+
+    assert mock_revision.get_file_content(binary_file.name, tmp_path) is None
+
+
 def test_clang_files(mock_revision):
     """
     Test clang files detection


### PR DESCRIPTION
Closes #3365. Binary files referenced by analysis issues could raise `UnicodeDecodeError` while building issue hashes and abort publication. Treat undecodable files like missing files so those issues are skipped, with a regression covering the WebP failure.
