### PR TITLE
Taskcluster v102 no longer supports normal priority - change to lowest

### DIFF
--- a/bot/taskcluster-hook.json
+++ b/bot/taskcluster-hook.json
@@ -75,7 +75,7 @@
       "image": "mozilla/code-review:REVISION",
       "maxRunTime": 7200
     },
-    "priority": "normal",
+    "priority": "lowest",
     "provisionerId": "aws-provisioner-v1",
     "retries": 3,
     "routes": ["index.project.relman.CHANNEL.code-review.latest"],

--- a/integration/taskcluster-hook.json
+++ b/integration/taskcluster-hook.json
@@ -40,7 +40,7 @@
       "image": "mozilla/code-review:integration-REVISION",
       "maxRunTime": 7200
     },
-    "priority": "normal",
+    "priority": "lowest",
     "provisionerId": "proj-relman",
     "retries": 1,
     "routes": [],


### PR DESCRIPTION
Prior to Taskcluster v102.0.1, task priority `normal` was internally [mapped](https://github.com/taskcluster/taskcluster/blob/05bfba092ae07bff31b232a1c502ee23ba08a46a/services/queue/src/api.js#L687) to `lowest`.

This sets it explicitly, since `normal` priority was removed in https://github.com/taskcluster/taskcluster/pull/8865 which was released in [Taskcluster v102.0.1](https://github.com/taskcluster/taskcluster/releases/tag/v102.0.1).