### PR TITLE
Avoid crashing on misconfigured Phabricator API

### DIFF
--- a/bot/code_review_bot/report/phabricator.py
+++ b/bot/code_review_bot/report/phabricator.py
@@ -171,6 +171,12 @@ class PhabricatorReporter(Reporter):
             )
             return
 
+        if not hasattr(self, "api"):
+            logger.warning(
+                "Phabricator API is not set: you need to configure credentials"
+            )
+            return
+
         # Add extra reviewers groups to the revision
         if reviewers:
             phids = []


### PR DESCRIPTION
Fixes the issue reported on sentry about missing `PhabricatorReporter.api`. This happens for invalid credentials or when phabricator reporting is disabled