### PR TITLE
Use importlib.metadata instead of pkg_resources

### DIFF
--- a/bot/code_review_bot/config.py
+++ b/bot/code_review_bot/config.py
@@ -6,12 +6,12 @@
 import atexit
 import collections
 import fnmatch
+import importlib.metadata
 import os
 import shutil
 import tempfile
 from pathlib import Path
 
-import pkg_resources
 import structlog
 
 REPO_MOZILLA_CENTRAL = "https://hg.mozilla.org/mozilla-central"
@@ -70,7 +70,7 @@ class Settings:
         # Always cleanup at the end of the execution
         atexit.register(self.cleanup)
         # caching the versions of the app
-        self.version = pkg_resources.require("code-review-bot")[0].version
+        self.version = importlib.metadata.version("code-review-bot")
 
     def setup(
         self,

--- a/bot/code_review_bot/tools/log.py
+++ b/bot/code_review_bot/tools/log.py
@@ -2,12 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import importlib.metadata
 import logging
 import logging.handlers
 import os
 import re
 
-import pkg_resources
 import sentry_sdk
 import structlog
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -116,7 +116,7 @@ def setup_sentry(name, channel, dsn):
         integrations=[sentry_logging],
         server_name=name,
         environment=channel,
-        release=pkg_resources.get_distribution(f"code-review-{name}").version,
+        release=importlib.metadata.version(f"code-review-{name}"),
         before_send=remove_color_codes,
     )
     sentry_sdk.set_tag("site", site)

--- a/tools/code_review_tools/log.py
+++ b/tools/code_review_tools/log.py
@@ -2,12 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import importlib.metadata
 import logging
 import logging.handlers
 import os
 import re
 
-import pkg_resources
 import sentry_sdk
 import structlog
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -116,7 +116,7 @@ def setup_sentry(name, channel, dsn):
         integrations=[sentry_logging],
         server_name=name,
         environment=channel,
-        release=pkg_resources.get_distribution(f"code-review-{name}").version,
+        release=importlib.metadata.version(f"code-review-{name}"),
         before_send=remove_color_codes,
     )
     sentry_sdk.set_tag("site", site)


### PR DESCRIPTION
pkg_resources has been deprecated for a while and has been removed in setuptools 82. This unlocks #3499 and #3520.