### PR TITLE
fix and improve cancellation of builds from previous diffs

### DIFF
--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -482,8 +482,8 @@ class Workflow:
 
     def cancel_previous(self, revision):
         """
-        Cancel the try pushes triggered by earlier updates of a revision, and
-        abort the HarborMaster buildables of those updates.
+        Cancel the code-review task, try pushes, and HarborMaster buildables of earlier
+        updates of a revision.
         """
 
         # In order to cancel tasks from a previous push we need the task group id
@@ -518,6 +518,17 @@ class Workflow:
             task_ids = []
 
         for task_id in task_ids:
+            # cancel the publication task, which may or may not be running still
+            try:
+                self.queue_service.cancelTask(task_id)
+                logger.info("Cancelled a previous publication task", task=task_id)
+            except Exception as e:
+                logger.warn(
+                    "Failed to cancel a previous publication task",
+                    task=task_id,
+                    error=str(e),
+                )
+
             # No need to check whether or not anything is active in the group;
             # cancelling is idempotent.
             task_group_id = self.find_try_decision_task(task_id)

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -49,7 +49,7 @@ TASKCLUSTER_NAMESPACE = "project.relman.{channel}.code-review.{name}"
 TASKCLUSTER_INDEX_TTL = 7  # in days
 
 DECISION_TASK_ROUTE = "gecko.v2.{repo}.revision.{revision}.taskgraph.decision"
-PUBLICATION_LOG_ARTIFACT = "public/logs/live.log"
+PUBLICATION_LOG_ARTIFACT = "public/logs/live_backing.log"
 TREEHERDER_LINK_REGEX = re.compile(
     rb"treeherder\.mozilla\.org/(?:#/)?jobs\?repo=(?P<repo>[\w-]+)"
     rb"&revision=(?P<revision>[0-9a-f]{12,40})"
@@ -654,7 +654,8 @@ class Workflow:
         """
         Find the decision task of the try push made by a publication task
 
-        The Treeherder link it published is only available in its own live log.
+        The Treeherder link it published is only available in its own backing
+        log, so this is only usable once that task has resolved.
         """
         url = self.queue_service.buildUrl(
             "getLatestArtifact", publication_task_id, PUBLICATION_LOG_ARTIFACT

--- a/bot/code_review_bot/workflow.py
+++ b/bot/code_review_bot/workflow.py
@@ -564,23 +564,42 @@ class Workflow:
         """
         List the HarborMaster buildables of the previous updates of a revision
 
-        The buildable of the diff being processed is left out: aborting it would
-        abort the build this very task is reporting to.
+        Only the buildables of the diffs preceding the one being processed are
+        returned. The buildable of the current diff is left out because aborting
+        it would abort the build this very task is reporting to, and those of
+        later diffs because they belong to updates that are themselves busy
+        superseding this one.
         """
         logger.debug("Finding previous buildables", phid=revision.phabricator_phid)
-        buildables = [
-            buildable
-            for buildable in self.phabricator.request(
-                "harbormaster.buildable.search",
-                constraints={"containerPHIDs": [revision.phabricator_phid]},
-            )["data"]
-            if buildable["fields"]["objectPHID"] != revision.diff_phid
-        ]
-        if not buildables:
+        buildables = self.phabricator.request(
+            "harbormaster.buildable.search",
+            constraints={"containerPHIDs": [revision.phabricator_phid]},
+        )["data"]
+
+        diff_phids = {buildable["fields"]["objectPHID"] for buildable in buildables} - {
+            revision.diff_phid
+        }
+        if not diff_phids:
             logger.debug("No previous buildables found", phid=revision.phabricator_phid)
             return []
 
-        buildable_phids = [b["phid"] for b in buildables]
+        diff_ids = {
+            diff["phid"]: diff["id"]
+            for diff in self.phabricator.request(
+                "differential.diff.search",
+                constraints={"phids": sorted(diff_phids)},
+            )["data"]
+        }
+
+        buildable_phids = []
+        for buildable in buildables:
+            diff_id = diff_ids.get(buildable["fields"]["objectPHID"])
+            if diff_id is not None and diff_id < revision.diff_id:
+                buildable_phids.append(buildable["phid"])
+
+        if not buildable_phids:
+            logger.debug("No previous buildables found", phid=revision.phabricator_phid)
+            return []
 
         logger.debug(
             "Found buildables",

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -518,6 +518,8 @@ class MockQueue:
         self.session = SessionMock()
         self.sealed_groups = []
         self.cancelled_groups = []
+        self.cancelled_tasks = []
+        self.task_states = {}
 
     def configure(self, relations):
         # Reset the session mock
@@ -611,6 +613,11 @@ class MockQueue:
         assert group_id in self.sealed_groups, "Task group must be sealed first"
         self.cancelled_groups.append(group_id)
         return {"taskGroupId": group_id, "taskIds": []}
+
+    def cancelTask(self, task_id):
+        self.cancelled_tasks.append(task_id)
+        self.task_states[task_id] = "exception"
+        return {"status": self.status(task_id)["status"]}
 
     def createArtifact(self, task_id, run_id, name, payload):
         if task_id not in self._artifacts:

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -340,13 +340,22 @@ BUILDABLES = {
     "PHID-HMBB-current": "PHID-DIFF-current",
 }
 
+DIFF_IDS = {
+    "PHID-DIFF-old": 1,
+    "PHID-DIFF-current": 2,
+    "PHID-DIFF-next": 3,
+}
 
-def mock_harbormaster(logs, buildables=BUILDABLES, abort_error=None):
+CURRENT_DIFF_ID = DIFF_IDS["PHID-DIFF-current"]
+
+
+def mock_harbormaster(logs, buildables=BUILDABLES, abort_error=None, diff_ids=DIFF_IDS):
     """
     Mock the Conduit calls used to cancel and abort the previous updates
 
     logs maps a file PHID to a (build target PHID, raw log content) tuple.
     buildables maps a buildable PHID to the PHID of the diff it builds.
+    diff_ids maps a diff PHID to its id, which orders the updates.
     abort_error is raised on every harbormaster.sendmessage call when set.
 
     Every buildable has a single build, itself having a single build target,
@@ -368,6 +377,15 @@ def mock_harbormaster(logs, buildables=BUILDABLES, abort_error=None):
                 "data": [
                     {"phid": phid, "fields": {"objectPHID": diff_phid}}
                     for phid, diff_phid in sorted(buildables.items())
+                ]
+            }
+
+        if path == "differential.diff.search":
+            return {
+                "data": [
+                    {"phid": phid, "id": diff_ids[phid]}
+                    for phid in payload["constraints"]["phids"]
+                    if phid in diff_ids
                 ]
             }
 
@@ -476,6 +494,7 @@ def test_cancel_previous(mock_config, mock_workflow):
     revision = mock.MagicMock(spec=PhabricatorRevision)
     revision.phabricator_phid = "PHID-DREV-1"
     revision.diff_phid = "PHID-DIFF-current"
+    revision.diff_id = CURRENT_DIFF_ID
     revision.build_target_phid = "PHID-HMBT-current"
 
     mock_workflow.cancel_previous(revision)
@@ -507,6 +526,7 @@ def test_cancel_previous_without_previous_build(mock_config, mock_workflow):
     revision = mock.MagicMock(spec=PhabricatorRevision)
     revision.phabricator_phid = "PHID-DREV-1"
     revision.diff_phid = "PHID-DIFF-current"
+    revision.diff_id = CURRENT_DIFF_ID
     revision.build_target_phid = "PHID-HMBT-current"
 
     mock_workflow.cancel_previous(revision)
@@ -529,6 +549,7 @@ def test_cancel_previous_without_publication_task(mock_config, mock_workflow):
     revision = mock.MagicMock(spec=PhabricatorRevision)
     revision.phabricator_phid = "PHID-DREV-1"
     revision.diff_phid = "PHID-DIFF-current"
+    revision.diff_id = CURRENT_DIFF_ID
     revision.build_target_phid = "PHID-HMBT-current"
 
     mock_workflow.cancel_previous(revision)
@@ -560,6 +581,7 @@ def test_cancel_previous_abort_failure(mock_config, mock_workflow):
     revision = mock.MagicMock(spec=PhabricatorRevision)
     revision.phabricator_phid = "PHID-DREV-1"
     revision.diff_phid = "PHID-DIFF-current"
+    revision.diff_id = CURRENT_DIFF_ID
     revision.build_target_phid = "PHID-HMBT-current"
 
     mock_workflow.cancel_previous(revision)
@@ -589,6 +611,7 @@ def test_cancel_previous_publication_tasks_failure(mock_config, mock_workflow):
     revision = mock.MagicMock(spec=PhabricatorRevision)
     revision.phabricator_phid = "PHID-DREV-1"
     revision.diff_phid = "PHID-DIFF-current"
+    revision.diff_id = CURRENT_DIFF_ID
     revision.build_target_phid = "PHID-HMBT-current"
 
     mock_workflow.cancel_previous(revision)
@@ -610,6 +633,7 @@ def test_cancel_previous_conduit_failure(mock_config, mock_workflow):
     revision = mock.MagicMock(spec=PhabricatorRevision)
     revision.phabricator_phid = "PHID-DREV-1"
     revision.diff_phid = "PHID-DIFF-current"
+    revision.diff_id = CURRENT_DIFF_ID
     revision.build_target_phid = "PHID-HMBT-current"
 
     mock_workflow.cancel_previous(revision)

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -640,3 +640,41 @@ def test_cancel_previous_conduit_failure(mock_config, mock_workflow):
 
     assert mock_workflow.queue_service.cancelled_groups == []
     mock_workflow.phabricator.request.assert_called_once()
+
+
+def test_cancel_previous_ignores_later_buildables(mock_config, mock_workflow):
+    """
+    The buildable of a later diff is left alone: it belongs to an update that is
+    itself superseding the one being processed
+    """
+    mock_config.taskcluster = TaskCluster("/tmp/dummy", "currentTask", 0, False)
+    mock_workflow.phabricator = mock_harbormaster(
+        {
+            "PHID-FILE-old-body": ("PHID-HMBT-old", '{"taskId": "oldPublicationTask"}'),
+            "PHID-FILE-next-body": (
+                "PHID-HMBT-next",
+                '{"taskId": "nextPublicationTask"}',
+            ),
+        },
+        buildables={
+            "PHID-HMBB-old": "PHID-DIFF-old",
+            "PHID-HMBB-current": "PHID-DIFF-current",
+            "PHID-HMBB-next": "PHID-DIFF-next",
+        },
+    )
+    mock_workflow.queue_service.task_states["oldPublicationTask"] = "running"
+    mock_workflow.queue_service.task_states["nextPublicationTask"] = "running"
+    mock_workflow.index_service.configure({})
+
+    revision = mock.MagicMock(spec=PhabricatorRevision)
+    revision.phabricator_phid = "PHID-DREV-1"
+    revision.diff_phid = "PHID-DIFF-current"
+    revision.diff_id = CURRENT_DIFF_ID
+    revision.build_target_phid = "PHID-HMBT-current"
+
+    mock_workflow.cancel_previous(revision)
+
+    assert mock_workflow.queue_service.cancelled_tasks == ["oldPublicationTask"]
+    assert abort_calls(mock_workflow.phabricator) == [
+        {"receiver": "PHID-HMBB-old", "type": "abort"}
+    ]

--- a/bot/tests/test_workflow.py
+++ b/bot/tests/test_workflow.py
@@ -409,7 +409,7 @@ def test_find_try_decision_task(mock_config, mock_workflow):
     """
     mock_workflow.queue_service.session.add(
         "get",
-        "http://tc.test/oldPublicationTask/artifacts/public/logs/live.log",
+        "http://tc.test/oldPublicationTask/artifacts/public/logs/live_backing.log",
         TREEHERDER_LOG,
     )
     mock_workflow.index_service.configure(
@@ -425,7 +425,7 @@ def test_find_try_decision_task_without_try_push(mock_config, mock_workflow):
     """
     mock_workflow.queue_service.session.add(
         "get",
-        "http://tc.test/oldPublicationTask/artifacts/public/logs/live.log",
+        "http://tc.test/oldPublicationTask/artifacts/public/logs/live_backing.log",
         "Nothing was pushed to try",
     )
     mock_workflow.index_service.configure({})
@@ -468,7 +468,7 @@ def test_cancel_previous(mock_config, mock_workflow):
     )
     mock_workflow.queue_service.session.add(
         "get",
-        "http://tc.test/oldPublicationTask/artifacts/public/logs/live.log",
+        "http://tc.test/oldPublicationTask/artifacts/public/logs/live_backing.log",
         TREEHERDER_LOG,
     )
     mock_workflow.index_service.configure({"decisionTask": {"route": DECISION_ROUTE}})
@@ -552,7 +552,7 @@ def test_cancel_previous_abort_failure(mock_config, mock_workflow):
     )
     mock_workflow.queue_service.session.add(
         "get",
-        "http://tc.test/oldPublicationTask/artifacts/public/logs/live.log",
+        "http://tc.test/oldPublicationTask/artifacts/public/logs/live_backing.log",
         TREEHERDER_LOG,
     )
     mock_workflow.index_service.configure({"decisionTask": {"route": DECISION_ROUTE}})


### PR DESCRIPTION
- Read `live_backing.log` instead of `live.log`
- Don't try to cancel things from newer diffs
- Cancel in-progress analysis tasks

More on each in the individual commits.